### PR TITLE
docs: add development workflow and CI for skill distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  shellcheck:
+    name: Shellcheck install.sh
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run shellcheck (warning severity — see docs/WORKFLOW.md §5)
+        run: shellcheck --severity=warning install.sh
+
+  skill-frontmatter:
+    name: Skill frontmatter and line budget
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check SKILL.md frontmatter and line budget
+        run: ./scripts/check-skill-frontmatter.sh
+
+  install-smoke-test:
+    name: install.sh smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: --list
+        run: ./install.sh --list
+      - name: copy install
+        run: ./install.sh --dest /tmp/rsc-install-test rust-api-design
+      - name: symlink install
+        run: ./install.sh --dest /tmp/rsc-install-test-symlink --symlink rust-api-design
+      - name: re-run without --force is skipped (no error, no overwrite)
+        run: ./install.sh --dest /tmp/rsc-install-test rust-api-design
+      - name: --force overwrites
+        run: ./install.sh --dest /tmp/rsc-install-test --force rust-api-design
+      - name: installed file is present and non-empty
+        run: test -s /tmp/rsc-install-test/.claude/skills/rust-api-design/SKILL.md

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ ref/comprehensive-rust/
 
 # OS cruft
 .DS_Store
+
+# Serena MCP local project state
+.serena/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,23 +62,32 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 
 ## 5. Testing
 
-- Iterate with a scoped run during development: `uv run pytest <path>` (a specific file or
-  directory, not the full suite).
-- Type check after any code change: `uv run mypy src`.
-- Before commit, run the full gate from `docs/WORKFLOW.md` §7 (`ruff check .`, `mypy src`,
-  `pytest --cov=subsched --cov-fail-under=80`) — see that section for the exact commands and the
-  branch-coverage baseline.
+This repo is a content repo (Claude Code skills, not an application), so "testing" means the
+gates in `docs/WORKFLOW.md`, not a unit-test suite.
 
-### TDD workflow (required for new features)
+- Changed a `SKILL.md`: run `./scripts/check-skill-frontmatter.sh` (frontmatter keys + line
+  budget) and follow the Draft → Validate → Refine cycle in `docs/WORKFLOW.md` §4 — in
+  particular the trigger-startup and non-duplication checks, and `/skill-stocktake` for any
+  skill you added or changed.
+- Changed `install.sh`: run `shellcheck --severity=warning install.sh` and the manual smoke test
+  in `docs/WORKFLOW.md` §5 (list / copy install / symlink install / skip-without-`--force` /
+  `--force` overwrite). The same checks run in CI (`.github/workflows/ci.yml`) — see
+  `docs/WORKFLOW.md` §7 for the full pre-PR gate.
+- Before commit, run `git diff --check` for whitespace issues, then the full gate in
+  `docs/WORKFLOW.md` §7.
 
-1. Write failing tests first. Do NOT implement yet.
-2. Run tests, confirm they fail for the right reason.
-3. Implement the minimal code to make tests pass.
-4. Do NOT modify tests to make them pass — fix the implementation.
-5. Run the full test command again before reporting done.
-6. If a test fails for an unrelated reason, stop and report — do not edit unrelated files.
+### Content-change workflow (required for skill edits)
+
+1. Read the relevant upstream Comprehensive Rust source page(s) before writing — don't
+   paraphrase from memory (`docs/WORKFLOW.md` §3.3, §4.1).
+2. Draft the content; state which upstream `source:` pin it derives from.
+3. Validate: frontmatter, line budget, trigger-startup, attribution, non-duplication against
+   `rust-patterns` and neighboring skills (`docs/WORKFLOW.md` §4.2).
+4. Refine based on what Validate found. Do not silently change a skill's `source:` pin, its
+   delineation from other skills, or the `skills/` vs `.claude/skills/` symlink structure.
 
 ### Verification is required
 
-- Never report a task as complete without running the relevant test command and showing output.
+- Never report a task as complete without running the relevant check command and showing
+  output.
 - Do not rely on your own summary as proof — the command output is the source of truth.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,84 @@
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No speculative error handling for truly internal impossible states. External input, persisted
+  state, filesystem, subprocess, authentication, billing, capacity, and security boundaries always
+  require explicit validation and fail-closed handling.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+## 5. Testing
+
+- Iterate with a scoped run during development: `uv run pytest <path>` (a specific file or
+  directory, not the full suite).
+- Type check after any code change: `uv run mypy src`.
+- Before commit, run the full gate from `docs/WORKFLOW.md` §7 (`ruff check .`, `mypy src`,
+  `pytest --cov=subsched --cov-fail-under=80`) — see that section for the exact commands and the
+  branch-coverage baseline.
+
+### TDD workflow (required for new features)
+
+1. Write failing tests first. Do NOT implement yet.
+2. Run tests, confirm they fail for the right reason.
+3. Implement the minimal code to make tests pass.
+4. Do NOT modify tests to make them pass — fix the implementation.
+5. Run the full test command again before reporting done.
+6. If a test fails for an unrelated reason, stop and report — do not edit unrelated files.
+
+### Verification is required
+
+- Never report a task as complete without running the relevant test command and showing output.
+- Do not rely on your own summary as proof — the command output is the source of truth.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -1,0 +1,313 @@
+# rust-skills-comprehensive 開発ワークフロー
+
+**最終更新:** 2026-08-29
+**対象:** `rust-skills-comprehensive` — Comprehensive Rustから派生したClaude Code skill集
+
+この文書は、このリポジトリでskillの追加・更新・`install.sh`の変更を行う際に、内容と
+distribution、attributionのずれを防ぐための手順を定義する。このリポジトリはコードでは
+なくClaude Code skill（`SKILL.md` + 付随ファイル）を配布するcontentリポジトリであり、
+自動テストの対象はshellcheck・frontmatter/line budget検証・`install.sh`のsmoke testに
+限られる（`.github/workflows/ci.yml`）。skillの内容自体の品質保証は`/skill-stocktake`と
+手動trigger testで行う。
+
+## 1. Source of truth
+
+作業前に次の順で確認する。
+
+1. [`docs/PLAN.md`](PLAN.md) — skillカタログ設計、モジュールsizing、build順序、Status log
+2. [`docs/FILE_MAP.md`](FILE_MAP.md) — upstream courseの約450ページのtopic別index
+3. [README](../README.md) — 配布されているskill一覧、install手順、repository layout
+4. 各`skills/<name>/SKILL.md` — 現在の内容と`source:`frontmatterのpin
+
+`docs/PLAN.md`はこのリポジトリの設計ドキュメントであり、GitHub Issueへの移行はしていない。
+新しい作業はまず`docs/PLAN.md`のStatus節に記録する。
+
+PLANとskill本文が矛盾する場合、実装者の判断だけでどちらかを変更しない。特に次の契約は、
+明示的な確認なしに緩和しない。
+
+- skillの内容はupstream Comprehensive Rustの`source:`pinから逸脱しない。加筆・言い換えを
+  超える主張（upstreamにない技術的結論）を追加しない
+- 各`SKILL.md`はCC-BY-4.0（本文）/ Apache-2.0（コード例）のattributionを
+  frontmatterの`source:`に保持する
+- 1 skill = 1 job（"診断する/設計する/実装する"）であり、`rust-patterns`が既に screen 1枚で
+  答えられる内容と重複させない（`docs/PLAN.md`の delineation ruleを参照）
+- `SKILL.md`は目安200行〜500行の予算を超えない。超える場合は`references/*.md`へ分割する
+- `ref/comprehensive-rust/`（gitignore対象、vendored course）はリポジトリに含めない
+- `.claude/skills/*`は`skills/*`へのsymlinkのまま保つ（配布物との二重管理を避ける）
+
+## 2. 作業を選ぶ
+
+`docs/PLAN.md`のStatus節と「Not yet done」を確認し、依存関係のある作業（例: 新skillが
+既存skillの参照を前提にする場合）は先に完了させる。
+
+作業範囲が曖昧な場合は、開始前に次を整理する。
+
+- 対応する`docs/PLAN.md`のセクション（Skill catalog / Module weights）
+- 変更対象のskill名・ファイルと非スコープ
+- upstream courseのどのpath（`ref/comprehensive-rust/src/**`）を参照するか
+- README・PLAN・FILE_MAPのどこを同期する必要があるか
+- attribution・line budget・重複回避の観点で確認すべき点
+
+新skillが大きすぎる場合は、`docs/PLAN.md`のModule weightsに倣ってjob単位で分割する。
+
+### 2.1 Issueからのプランニング
+
+作業がGitHub Issue（バグ報告・機能要望など）から始まる場合、実装に着手する前に次を行う。
+
+1. `gh issue view <ISSUE> --json number,title,body,comments,labels,state,url`でIssue本文と
+   コメントを確認する。`<ISSUE>`には確認済みの正整数だけを使い、Issue本文などの外部入力を
+   shell commandへ貼り付けない
+2. Issueの内容を§1の不変条件（upstream逸脱禁止、attribution維持、delineation、line budget
+   等）およびdocs/PLAN.mdの既存設計と突き合わせ、実装プランを作成する。プランには最低限
+   次を含める。
+   - 対応するIssue番号と要求の要約
+   - 変更対象のskill/ファイルと非スコープ
+   - `docs/PLAN.md`・READMEなど同期が必要なdocs
+   - upstream courseのどのpathを参照するか（skill内容変更の場合）
+   - 手順ごとの検証方法（例: `1. [手順] → verify: [確認内容]`）
+3. 作成したプランをplanning-reviewサブエージェント（`planner`または`architect`など、直接
+   コードを書かないread-only系エージェント）でレビューさせる。レビューは実装着手**前**に
+   行い、次を確認させる。
+   - Issueの要求を過不足なくカバーしているか（scope漏れ・過剰スコープ）
+   - §1の不変条件・delineation ruleに反する設計がないか
+   - 依存する他skillやdocsへの影響が洗い出されているか
+4. レビューで指摘があれば計画を修正し、再度整合性を確認してから§3以降の実装に進む。指摘と
+   対応はIssueコメントまたは作業メモに記録する
+
+軽微な修正（typo、単一リンク切れ等）でプラン作成が明らかに過剰な場合は、この工程を省略して
+よい。省略した理由を判断できる程度に留める。
+
+## 3. 作業開始
+
+### 3.1 mainを同期する
+
+```bash
+git switch main
+git pull --ff-only
+git status --short --branch
+```
+
+未追跡ファイルや別作業の差分は所有者の変更として保持する。`git reset --hard`、広い
+`git clean`、無関係なファイルへの`git checkout --`は使用しない。
+
+### 3.2 作業branchを作る
+
+```bash
+git switch -c skill/<short-description>
+```
+
+例: `skill/rust-error-handling`、`docs/update-file-map`。1 branchには1つのまとまった変更
+（1 skillの追加/更新、または1つのdocs更新）だけを含める。
+
+### 3.3 upstream courseを準備する（skill内容を編集する場合のみ）
+
+```bash
+git clone https://github.com/google/comprehensive-rust ref/comprehensive-rust
+cd ref/comprehensive-rust && git checkout <pinned-commit> && cd -
+```
+
+`ref/`はgitignore対象で、配布物には含まれない。既存skillの`source:`frontmatterに記載された
+commitと異なる版を使う場合は、更新後にpinを書き換える（§8）。
+
+## 4. Skill執筆サイクル
+
+新規skillの追加、既存skillの修正はDraft → Validate → Refineで進める。
+
+### 4.1 Draft
+
+- 対象のupstream page(s)を`ref/comprehensive-rust/src/**`から読み、それぞれの
+  `minutes:`frontmatterでboundaryの妥当性を確認する
+- `docs/PLAN.md`の該当skillの"Draft description"・Sourcesを出発点にし、job指向の
+  frontmatter `description`を書く（"何についてのskillか"ではなく"いつ使うか"）
+- 本文はpattern/pitfallを中心に構成し、upstreamの散文をそのまま転記しない
+- 既存skill（特に`rust-patterns`と、topicが近い他のRust skill）と内容が重複していないか
+  `docs/PLAN.md`のdelineation tableで確認する
+
+### 4.2 Validate
+
+新規/変更したskillごとに次を確認する。
+
+| 確認項目 | 方法 |
+| --- | --- |
+| Frontmatter形式 | `name`・`description`・`source`が揃っている。`description:`の inline code内に`:`直後の空白を含めない（過去に発生したparser不具合、`docs/PLAN.md`参照）。`./scripts/check-skill-frontmatter.sh`（CIの`skill-frontmatter` jobと同じ）で機械的に確認できる |
+| Line budget | 同スクリプトが500行のhard budgetを超えていないかCIで検査する。ソフトな目安（既存skillのレンジ137–233行）から大きく外れる場合は`references/`分割を検討する——こちらはCIでは強制しない |
+| Trigger起動性 | そのskillが起動すべき/すべきでない代表的なpromptを数個想定し、`description`の語彙で自己判別できるか確認する（近縁skillとの誤起動がないか） |
+| Attribution | `source:`のCC-BY-4.0/Apache-2.0表記とpinned commitが正しい |
+| 重複回避 | `rust-patterns`や他skillの既存section と同じ結論しか出せない内容になっていないか |
+
+複数skillを変更した場合、または新skillを追加した場合は`/skill-stocktake`を該当skillに
+scopeして実行し、Keep/Fix/Dropの判定を`docs/PLAN.md`のStatusへ記録する。
+
+### 4.3 Refine
+
+Validateで見つかった問題を修正し、同じ確認を再実行する。次を暗黙に変更しない。
+
+- 既にpinされた`source:`のcommit（意図的な更新以外）
+- 他skillとの役割分担（delineation table）
+- 配布構造（`skills/`が正、`.claude/skills/`はsymlink）
+
+## 5. `install.sh`を変更する場合
+
+`install.sh`はこのリポジトリの配布経路そのものであり、壊れると全skillが利用不能になる。
+変更時は必ず手動で次を確認する。
+
+```bash
+./install.sh --list                                  # skill一覧が正しく出るか
+./install.sh --dest /tmp/rsc-install-test <name>      # 単一skill install
+./install.sh --dest /tmp/rsc-install-test --symlink <name>  # symlink install
+./install.sh --dest /tmp/rsc-install-test <name>      # 既存install（--forceなし）がskipされるか
+./install.sh --dest /tmp/rsc-install-test --force <name>    # --forceでの上書き
+rm -rf /tmp/rsc-install-test
+```
+
+同じ手順は`.github/workflows/ci.yml`の`install-smoke-test` jobでも`rust-api-design`を対象に
+自動実行される（CIの実行環境で完結し、開発者のhome/globalなskill installには触れない）。
+push/PRで自動的に再確認されるが、ローカルでも変更直後に一度手で流す。
+
+`shellcheck --severity=warning install.sh`もCIの`shellcheck` jobで実行される
+（info levelの指摘、例: `ls`より`find`を推奨、は対象外——このworkflow変更のために
+`install.sh`本体の無関係な書き換えを誘発しないための閾値）。ローカルでも同じコマンドで
+再現できる。
+
+bashは3.2互換を維持する（macOS標準bash）。bash 4以降専用の構文（連想配列、`readarray`等）
+は使わない。
+
+## 6. セキュリティと復旧
+
+配布物はテキストのみ（Markdown・shell script）であり、secretやcredentialを扱わない。
+それでも次は確認する。
+
+- skillやdocsの例に実際のtoken・APIキー・個人pathを含めない
+- `install.sh`はユーザーのhome/projectへ書き込むため、対象pathを引数から検証し、
+  意図しないディレクトリへの書き込み（例: 引数未検証での`rm -rf`拡大）を作らない
+- 破壊的な変更（`--force`での上書き、symlink化）はdefaultにしない
+
+## 7. 変更前後の確認（quality gate）
+
+PR前に次を実行する。
+
+```bash
+git status --short --branch
+git diff --check                 # 空白・改行の混在を検出
+./scripts/check-skill-frontmatter.sh
+shellcheck --severity=warning install.sh
+```
+
+上記2つは`.github/workflows/ci.yml`でpush/PR時に自動実行されるが、フィードバックを早く
+得るためローカルでも変更直後に実行する。ただしCIが検証するのは配布経路（frontmatterの
+必須key・line budget・`install.sh`のsmoke test）だけであり、skillの技術的内容の正しさは
+自動化されていない。次は引き続き手動確認に代える。
+
+- 変更した`SKILL.md`をfrontmatterから通読し、コードブロックのRustが構文的に妥当か目視確認する
+  （`rustc --edition 2021 --crate-type lib -` にコード片を通して素早く構文チェックしてよい。
+  多くのコード片は`{ ... }`のような省略記法を含み完全な構文にならないため、これはCIの
+  hard gateにはしていない）
+- `install.sh`を変更した場合は§5の手動テストを実行する（CIと同じ内容だが、CI未実行の段階
+  でも確認できる）
+- 新規/変更skillに対して`/skill-stocktake`を実行する（複数skillへの波及がある場合はglobal
+  scopeも検討するが、対象外にした場合はその旨をPLANに記録する）
+
+実行できない確認をPASSと表現しない。CIがまだ実行されていない、または落ちている状態を
+PASSとして報告しない。
+
+## 8. ドキュメントの同期
+
+次の変更は、内容の変更と同じPRでdocsを更新する。
+
+| 変更 | 同期先 |
+| --- | --- |
+| skillの追加・削除 | README（skill表・repository layout）、`docs/PLAN.md`（Skill catalog・Status） |
+| skillの`source:`pin更新 | 同じskillの他の記述箇所、必要なら`docs/PLAN.md`のUpstream pin |
+| skill間のdelineation変更 | `docs/PLAN.md`のdelineation table、影響するskillの相互参照 |
+| `install.sh`の挙動変更 | README（Install節）、`.github/workflows/ci.yml`のsmoke test手順 |
+| upstream courseの構造変化 | `docs/FILE_MAP.md` |
+| CIのjob・閾値変更 | このWORKFLOW（§5・§7・§9.2） |
+
+PLANやREADMEと乖離した状態でskill本文だけをmergeしない。
+
+## 9. コミットとPull Request
+
+対象ファイルだけをstageする。
+
+```bash
+git status --short --branch
+git diff --check
+git diff
+git add <explicit-files>
+git diff --cached --check
+git commit -m "<type>: <description>"
+git push -u origin "$(git branch --show-current)"
+```
+
+Conventional Commitのtypeは`feat`、`fix`、`refactor`、`docs`、`chore`から選ぶ（skillの追加は
+`feat`、内容修正は`fix`または`docs`、`install.sh`の挙動変更は`feat`/`fix`）。無関係な
+`ref/`の変更や、生成物・個人pathを含めない。`git push`はユーザーから明示的に許可された
+場合だけ実行し、force pushは使用しない。mainへの反映はPR経由を基本とする。
+
+初期repository文書やCI導入などのbootstrap作業に限り、ユーザーが対象ファイルとmainへの
+直接pushを明示した場合は例外を認める。通常のskill追加・修正にはこの例外を使わない。
+
+### 9.1 PR作成後のサブエージェントレビュー
+
+PRを作成したら、mergeする前に**必ず**code-reviewサブエージェント（`code-reviewer`または
+同等のreview agent）を起動し、diffのレビューを受ける。人間のレビューを代替するものでは
+なく、次を機械的に見落とさないための追加ゲートとして扱う。
+
+- 対象は`git diff main...HEAD`（そのPRの全commit、直近commitだけではない）
+- 確認観点は本文中心のこのリポジトリに合わせ、少なくとも次を含める。
+  - upstream Comprehensive Rustの主張から逸脱していないか（source-to-sinkでpinされた
+    upstream pathと照合）
+  - `source:`frontmatterのattribution（CC-BY-4.0/Apache-2.0）とpinned commitの正しさ
+  - `rust-patterns`や近縁skillとの内容重複
+  - `install.sh`を変更した場合はshellスクリプトとしての安全性（引数未検証のpath展開、
+    `rm -rf`の対象拡大など）
+- レビュー指摘はseverityだけで採否を決めず、該当行と根拠（矛盾するupstream source、
+  重複するskill section等）で検証する。High以上の妥当な指摘はmerge前に修正する
+- レビュー結果（実行した/しなかった、指摘と対応）をPR本文または§10のチェックリストに記録する
+
+### 9.2 マージ前の確認
+
+サブエージェントレビュー完了後、mergeする前に次を確認する。
+
+```bash
+git fetch origin main
+git merge-base --is-ancestor origin/main HEAD && echo "up to date with main" || echo "rebase/merge needed"
+gh pr view <PR> --json mergeable,mergeStateStatus
+```
+
+- `mergeable`が`CONFLICTING`の場合、force pushで上書きせず、mainを取り込んでから
+  コンフリクトを解消し、§4〜§9を再実行する（コンフリクト解消で意図せず他人の変更を消さない）
+- `gh pr checks <PR>`（または`--watch`）で`.github/workflows/ci.yml`の全job
+  （`shellcheck` / `skill-frontmatter` / `install-smoke-test`）がgreenであることを確認して
+  からmergeする。落ちているjobがある場合、原因を修正せずmergeしない
+- 上記いずれも未実行のままmergeしない
+
+PR本文には次を記載する。
+
+- 対応する`docs/PLAN.md`のセクション、または動機
+- 変更内容（追加/更新したskill、または`install.sh`/docsの変更）と理由
+- attribution・重複回避・line budgetへの影響
+- 実行した確認（§7）と`/skill-stocktake`の結果
+- 実行できなかった確認とその理由
+
+## 10. レビューと完了条件
+
+skill/docsの変更はmerge前に内容と配布経路の両面でレビューする。指摘は再現手順（該当行、
+矛盾するupstream source、または誤起動するprompt例）で検証する。
+
+変更は次をすべて満たした場合だけ完了とする。
+
+- [ ] Issue起点の作業の場合、§2.1のプランニングとサブエージェントレビューを実施した
+- [ ] `docs/PLAN.md`のdelineationおよびAttribution requirementを満たした
+- [ ] Draft → Validate → Refineの証跡がある
+- [ ] `description:`のtrigger起動性を確認した（誤起動・無起動がない）
+- [ ] `source:`frontmatterのattributionとpinが正しい
+- [ ] `install.sh`を変更した場合、§5の手動テストを実行した
+- [ ] README、`docs/PLAN.md`、`docs/FILE_MAP.md`が実装と一致する
+- [ ] PR作成後にcode-reviewサブエージェント（§9.1）でレビューし、High以上の指摘に対応した
+- [ ] mainとのコンフリクトがないこと、`.github/workflows/ci.yml`の全jobがgreenであることを
+      §9.2で確認した
+- [ ] PRに確認結果と未確認事項を記録した
+
+ファイル構成は変化するため、この文書に静的tree snapshotは置かない。確認時は
+`git ls-files`と`docs/PLAN.md`を正とする。

--- a/scripts/check-skill-frontmatter.sh
+++ b/scripts/check-skill-frontmatter.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Verify every skills/*/SKILL.md has the required frontmatter keys (name,
+# description, source) and stays within the hard line budget from
+# docs/WORKFLOW.md §1 (500 lines). Exits non-zero on the first violation
+# found, after reporting every violation.
+#
+# Usage: ./scripts/check-skill-frontmatter.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILLS_DIR="$SCRIPT_DIR/../skills"
+MAX_LINES=500
+
+status=0
+
+for skill_md in "$SKILLS_DIR"/*/SKILL.md; do
+  name="$(basename "$(dirname "$skill_md")")"
+
+  # Frontmatter must start on line 1 and close with a second '---' line.
+  if [[ "$(sed -n '1p' "$skill_md")" != "---" ]]; then
+    echo "FAIL: $skill_md — does not start with '---' frontmatter delimiter"
+    status=1
+    continue
+  fi
+
+  frontmatter="$(awk 'NR==1{next} /^---$/{exit} {print}' "$skill_md")"
+
+  for key in name description source; do
+    if ! printf '%s\n' "$frontmatter" | grep -qE "^${key}:"; then
+      echo "FAIL: $skill_md — missing '${key}:' frontmatter key"
+      status=1
+    fi
+  done
+
+  # name: value should match the directory name.
+  fm_name="$(printf '%s\n' "$frontmatter" | sed -n 's/^name: *//p' | head -1)"
+  if [[ -n "$fm_name" && "$fm_name" != "$name" ]]; then
+    echo "FAIL: $skill_md — frontmatter name '$fm_name' != directory name '$name'"
+    status=1
+  fi
+
+  lines="$(wc -l < "$skill_md" | tr -d ' ')"
+  if (( lines > MAX_LINES )); then
+    echo "FAIL: $skill_md — $lines lines exceeds the ${MAX_LINES}-line budget (docs/WORKFLOW.md §1)"
+    status=1
+  fi
+done
+
+exit "$status"


### PR DESCRIPTION
## Summary

- Adds `docs/WORKFLOW.md`, adapted to this repo's actual shape (a Claude Code
  skill-distribution content repo, not a code service): source-of-truth order
  (`docs/PLAN.md` / `docs/FILE_MAP.md` / README / each `SKILL.md`), Issue-driven
  planning with a subagent review before implementation (§2.1), the
  Draft → Validate → Refine skill-authoring cycle (§4), `install.sh` change
  verification (§5), a post-PR subagent code review gate (§9.1), and a
  pre-merge conflict/CI check (§9.2).
- Adds `.github/workflows/ci.yml` with three jobs: `shellcheck` (warning
  severity, so pre-existing info-level `install.sh` findings aren't forced
  into an unrelated rewrite), `skill-frontmatter` (required frontmatter keys +
  500-line hard budget), and `install-smoke-test` (list / copy install /
  symlink install / skip-without-`--force` / `--force` overwrite, mirroring
  the manual steps WORKFLOW.md already documented).
- Adds `scripts/check-skill-frontmatter.sh` backing the frontmatter job.

## Scope

Deliberately excluded: automated Rust-syntax checking of code fences inside
`SKILL.md`. Most fences are intentionally incomplete snippets (e.g. `{ ... }`
placeholders), so a hard syntax gate would produce constant false failures —
documented as a manual, optional check in WORKFLOW.md §7 instead.

## Verification

- `./scripts/check-skill-frontmatter.sh` — passes against all 11 skills.
- `shellcheck --severity=warning install.sh` — passes (info-level SC2012/SC2035
  left as-is, not touched).
- Ran each `install-smoke-test` step manually against `rust-api-design` in an
  isolated scratch dir: `--list`, copy install, symlink install, re-run without
  `--force` (skipped), `--force` overwrite, and confirmed the installed
  `SKILL.md` is present and non-empty. All passed.
- Not yet observed: the workflow's actual run on GitHub Actions (first run
  happens once this PR's CI executes) — will confirm it's green before merge
  per WORKFLOW.md §9.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)