### PR TITLE
feat: sync Project Status to In Progress on manual claude-code label

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -1,0 +1,105 @@
+# Auto-implement an Issue with Claude Code when it's labeled `claude-code`.
+#
+# Flow: label added -> this issue's Project item is moved to "In Progress" ->
+# anthropics/claude-code-action reads the issue, implements it, and opens a PR
+# (following docs/WORKFLOW.md's Draft/Validate/Refine and PR conventions as
+# far as the action's own prompt can enforce). Merging that PR flips the
+# Project item to "Done" via the Project's built-in "Pull request merged"
+# workflow — no extra step needed here for that part.
+#
+# Required repository secrets (not set by this workflow — add via
+# `gh secret set <NAME>` or the repo Settings UI):
+#   ANTHROPIC_API_KEY — Anthropic API key for the Claude Code action.
+#   PROJECTS_TOKEN     — a personal access token with the `project` scope,
+#                        used only to move the Project item to "In Progress".
+#                        The default GITHUB_TOKEN cannot write to a
+#                        user-owned Project (v2), so this is unfortunately a
+#                        separate token from the one issues/PRs use.
+#
+# The "move to In Progress" step is best-effort (continue-on-error): if the
+# issue isn't in the project yet, or PROJECTS_TOKEN is missing/misscoped,
+# implementation still proceeds — only the Project board reflects it late.
+
+name: Claude Code auto-implement
+
+on:
+  issues:
+    types: [labeled]
+
+# IDs below are specific to https://github.com/users/takurot/projects/1
+# (owner: takurot). Re-fetch and update these if the project is recreated
+# or its Status field/options are edited:
+#   gh api graphql -f query='
+#     query($login: String!, $number: Int!) {
+#       user(login: $login) { projectV2(number: $number) { id
+#         field(name: "Status") { ... on ProjectV2SingleSelectField {
+#           id options { id name } } } } } }' -f login=takurot -F number=1
+env:
+  PROJECT_ID: PVT_kwHOAmN8-84Bh1Sx
+  STATUS_FIELD_ID: PVTSSF_lAHOAmN8-84Bh1Sxzhgvjx4
+  IN_PROGRESS_OPTION_ID: 47fc9ee4
+
+jobs:
+  implement:
+    if: github.event.label.name == 'claude-code'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Move project item to In Progress
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
+          PROJECTS_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
+          ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${PROJECTS_TOKEN:-}" ]]; then
+            echo "PROJECTS_TOKEN secret not set — skipping Status update." >&2
+            exit 0
+          fi
+
+          item_id="$(gh api graphql -f query='
+            query($issueId: ID!) {
+              node(id: $issueId) {
+                ... on Issue {
+                  projectItems(first: 20) {
+                    nodes { id project { id } }
+                  }
+                }
+              }
+            }' -f issueId="$ISSUE_NODE_ID" \
+            --jq ".data.node.projectItems.nodes[] | select(.project.id == \"$PROJECT_ID\") | .id" \
+            | head -1)"
+
+          if [[ -z "$item_id" ]]; then
+            echo "Issue is not (yet) an item in $PROJECT_ID — skipping Status update." >&2
+            exit 0
+          fi
+
+          gh api graphql -f query='
+            mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $projectId
+                itemId: $itemId
+                fieldId: $fieldId
+                value: { singleSelectOptionId: $optionId }
+              }) {
+                projectV2Item { id }
+              }
+            }' \
+            -f projectId="$PROJECT_ID" \
+            -f itemId="$item_id" \
+            -f fieldId="$STATUS_FIELD_ID" \
+            -f optionId="$IN_PROGRESS_OPTION_ID"
+
+      - name: Implement with Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          label_trigger: claude-code
+          track_progress: "true"

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -1,26 +1,30 @@
-# Auto-implement an Issue with Claude Code when it's labeled `claude-code`.
+# Move an Issue's Project item to "In Progress" when a `claude-code` label
+# signals that manual work on it has started.
 #
-# Flow: label added -> this issue's Project item is moved to "In Progress" ->
-# anthropics/claude-code-action reads the issue, implements it, and opens a PR
-# (following docs/WORKFLOW.md's Draft/Validate/Refine and PR conventions as
-# far as the action's own prompt can enforce). Merging that PR flips the
-# Project item to "Done" via the Project's built-in "Pull request merged"
-# workflow — no extra step needed here for that part.
+# This intentionally does NOT run any agent automatically. An earlier
+# version of this workflow also invoked anthropics/claude-code-action on the
+# same label to auto-implement the issue — that was removed after a
+# security review flagged it as a prompt-injection risk against a
+# privileged agent: any labeled issue's body/title (attacker-influenceable
+# text) was fed to an agent holding contents/pull-requests/issues write
+# permissions. Task instructions are given to Claude Code manually
+# (interactive sessions) instead; this workflow only keeps the Project
+# board's Status field honest about when that manual work starts.
 #
-# Required repository secrets (not set by this workflow — add via
-# `gh secret set <NAME>` or the repo Settings UI):
-#   ANTHROPIC_API_KEY — Anthropic API key for the Claude Code action.
-#   PROJECTS_TOKEN     — a personal access token with the `project` scope,
-#                        used only to move the Project item to "In Progress".
-#                        The default GITHUB_TOKEN cannot write to a
-#                        user-owned Project (v2), so this is unfortunately a
-#                        separate token from the one issues/PRs use.
+# To signal "starting work on issue #N": `gh issue edit N --add-label claude-code`
+# (or ask Claude Code to do it — an interactive `gh` session already
+# authenticated with the `project` scope can call the same GraphQL mutation
+# directly, without this workflow at all).
 #
-# The "move to In Progress" step is best-effort (continue-on-error): if the
-# issue isn't in the project yet, or PROJECTS_TOKEN is missing/misscoped,
-# implementation still proceeds — only the Project board reflects it late.
+# Required repository secret:
+#   PROJECTS_TOKEN — a personal access token with the `project` scope.
+#                    GITHUB_TOKEN can't write to a user-owned Project (v2).
+#                    This job requests no repository permissions of its own
+#                    (permissions: {} below) — it only calls the Projects
+#                    GraphQL API with this token, and never checks out or
+#                    reads repository content.
 
-name: Claude Code auto-implement
+name: Mark project item In Progress
 
 on:
   issues:
@@ -40,16 +44,11 @@ env:
   IN_PROGRESS_OPTION_ID: 47fc9ee4
 
 jobs:
-  implement:
+  mark-in-progress:
     if: github.event.label.name == 'claude-code'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+    permissions: {}
     steps:
-      - uses: actions/checkout@v4
-
       - name: Move project item to In Progress
         continue-on-error: true
         env:
@@ -96,10 +95,3 @@ jobs:
             -f itemId="$item_id" \
             -f fieldId="$STATUS_FIELD_ID" \
             -f optionId="$IN_PROGRESS_OPTION_ID"
-
-      - name: Implement with Claude Code
-        uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          label_trigger: claude-code
-          track_progress: "true"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/claude-code.yml`. When an issue is labeled
`claude-code` (signaling manual work has started on it), its item in
https://github.com/users/takurot/projects/1 is moved to **In Progress**
via a `updateProjectV2ItemFieldValue` GraphQL mutation. Best-effort
(`continue-on-error: true`): a missing/misscoped token or an issue not yet
in the project just skips the update.

Merging a PR that closes/references the issue still flips its Project item
to **Done** automatically via the project's existing `Pull request merged`
workflow (confirmed enabled) — no wiring needed for that half.

## Revision: auto-implementation removed

An earlier version of this PR also ran `anthropics/claude-code-action` on
the same label to auto-implement the issue. **Removed** after a background
security review flagged it as a prompt-injection risk against a privileged
agent: any `claude-code`-labeled issue's body/title (attacker-influenceable
text, since anyone able to label an issue could shape it) was fed to an
agent holding `contents`/`pull-requests`/`issues` write permissions.

This also matches the current intent — task instructions go to Claude Code
manually (interactive sessions), not via an auto-triggered agent — so the
job now:
- Has `permissions: {}` — no repository write access of any kind.
- Never checks out or reads repository content.
- Only calls the Projects GraphQL API using `PROJECTS_TOKEN`.

## Required secret

| Secret | Purpose |
| --- | --- |
| `PROJECTS_TOKEN` | PAT with the `project` scope — `GITHUB_TOKEN` cannot write to a user-owned Project (v2) |

(`ANTHROPIC_API_KEY` is no longer needed by this workflow.)

## Verification

- `python3 -c "import yaml; yaml.safe_load(open(...))"` — parses cleanly.
- `actionlint .github/workflows/claude-code.yml` — no findings beyond two
  intentional info-level shellcheck notes (GraphQL variable syntax
  correctly left unexpanded inside single-quoted query strings).
- Not yet verified: an actual run (needs `PROJECTS_TOKEN`, not set yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)