### PR TITLE
feat: CI checks for skill description safety, install-list sync, and link validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,12 @@ on:
 
 jobs:
   shellcheck:
-    name: Shellcheck install.sh
+    name: Shellcheck install.sh and scripts/*.sh
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Run shellcheck (warning severity — see docs/WORKFLOW.md §5)
-        run: shellcheck --severity=warning install.sh
+        run: shellcheck --severity=warning install.sh scripts/*.sh
 
   skill-frontmatter:
     name: Skill frontmatter and line budget
@@ -21,6 +21,22 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check SKILL.md frontmatter and line budget
         run: ./scripts/check-skill-frontmatter.sh
+
+  install-list-sync:
+    name: install.sh --list matches skills/
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check install.sh --list vs skills/ directories
+        run: ./scripts/check-install-list-sync.sh
+
+  link-check:
+    name: Skill/docs cross-reference links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check relative links and [[name]] references
+        run: ./scripts/check-links.sh
 
   install-smoke-test:
     name: install.sh smoke test

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -43,6 +43,20 @@ vendor the upstream course's two license texts at the repo root.
 (platform skills — still gated on user confirmation), exercise-based eval against the course's
 own exercises/solutions.
 
+**CI hardening (2026-08-31, issues #1–#3)**: closed a real gap in `skill-frontmatter` —
+the script checked presence of frontmatter keys but never caught the actual `rust-pinning`
+regression class above (a `: ` inside an unquoted YAML `description:` value truncates it);
+fixed by failing on any `: ` in the description value, not just inside backticks. Added two
+new CI jobs: `install-list-sync` (`./install.sh --list` vs `skills/*/` — a regression guard;
+`install.sh`'s `--list` already derives from the same glob, so this can't catch drift today,
+only a future refactor that reintroduces it) and `link-check` (relative Markdown links and
+double-bracket refs (e.g. `[[rust-pinning]]`) across `skills/**/*.md`, `README.md`,
+`docs/*.md`). `link-check` intentionally
+does not flag bare-word skill-name mentions in prose (`rust-patterns`, `rust-analyzer`, etc.
+are legitimate references to things outside this repo) — a dangling bare reference to a
+not-yet-built skill (the `rust-bare-metal` defect above) stays a `/skill-stocktake` concern,
+not a script one. `shellcheck` job widened to `scripts/*.sh`.
+
 Source map: [`FILE_MAP.md`](./FILE_MAP.md). Goal: turn Google's Comprehensive Rust course into
 a set of Claude Code **skills** (`SKILL.md` + `references/`), each scoped tightly enough to
 load fast and stay focused, together covering the course's teaching value — not a transcription

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -129,11 +129,12 @@ commitと異なる版を使う場合は、更新後にpinを書き換える（§
 
 | 確認項目 | 方法 |
 | --- | --- |
-| Frontmatter形式 | `name`・`description`・`source`が揃っている。`description:`の inline code内に`:`直後の空白を含めない（過去に発生したparser不具合、`docs/PLAN.md`参照）。`./scripts/check-skill-frontmatter.sh`（CIの`skill-frontmatter` jobと同じ）で機械的に確認できる |
+| Frontmatter形式 | `name`・`description`・`source`が揃っている。`description:`は引用符なしのYAML plain scalarなので、値のどこであれ`: `（コロン+空白）を含めると値がそこで切れる（過去に発生したparser不具合、`docs/PLAN.md`参照）。`./scripts/check-skill-frontmatter.sh`（CIの`skill-frontmatter` jobと同じ）で機械的に確認できる |
 | Line budget | 同スクリプトが500行のhard budgetを超えていないかCIで検査する。ソフトな目安（既存skillのレンジ137–233行）から大きく外れる場合は`references/`分割を検討する——こちらはCIでは強制しない |
 | Trigger起動性 | そのskillが起動すべき/すべきでない代表的なpromptを数個想定し、`description`の語彙で自己判別できるか確認する（近縁skillとの誤起動がないか） |
 | Attribution | `source:`のCC-BY-4.0/Apache-2.0表記とpinned commitが正しい |
 | 重複回避 | `rust-patterns`や他skillの既存section と同じ結論しか出せない内容になっていないか |
+| リンク・相互参照 | `SKILL.md`/README/`docs/*.md`内の相対Markdownリンクと二重角括弧参照（例: `[[rust-pinning]]`）が実在するファイル/skillを指しているか。`./scripts/check-links.sh`（CIの`link-check` job）で機械的に確認できる。ただし本文中の裸のskill名の言及（例: `rust-patterns`のような本リポジトリ外のskillへの意図的な言及）はチェック対象外——存在しないskillへの裸の言及（例: 過去の`rust-bare-metal`未整合）は引き続き`/skill-stocktake`など手動確認に委ねる |
 
 複数skillを変更した場合、または新skillを追加した場合は`/skill-stocktake`を該当skillに
 scopeして実行し、Keep/Fix/Dropの判定を`docs/PLAN.md`のStatusへ記録する。
@@ -164,13 +165,14 @@ rm -rf /tmp/rsc-install-test
 自動実行される（CIの実行環境で完結し、開発者のhome/globalなskill installには触れない）。
 push/PRで自動的に再確認されるが、ローカルでも変更直後に一度手で流す。
 
-`shellcheck --severity=warning install.sh`もCIの`shellcheck` jobで実行される
+`shellcheck --severity=warning install.sh scripts/*.sh`もCIの`shellcheck` jobで実行される
 （info levelの指摘、例: `ls`より`find`を推奨、は対象外——このworkflow変更のために
 `install.sh`本体の無関係な書き換えを誘発しないための閾値）。ローカルでも同じコマンドで
 再現できる。
 
 bashは3.2互換を維持する（macOS標準bash）。bash 4以降専用の構文（連想配列、`readarray`等）
-は使わない。
+は使わない。`scripts/*.sh`（`check-skill-frontmatter.sh`・`check-install-list-sync.sh`・
+`check-links.sh`）も同じ制約に従う。
 
 ## 6. セキュリティと復旧
 
@@ -190,13 +192,16 @@ PR前に次を実行する。
 git status --short --branch
 git diff --check                 # 空白・改行の混在を検出
 ./scripts/check-skill-frontmatter.sh
-shellcheck --severity=warning install.sh
+./scripts/check-install-list-sync.sh
+./scripts/check-links.sh
+shellcheck --severity=warning install.sh scripts/*.sh
 ```
 
-上記2つは`.github/workflows/ci.yml`でpush/PR時に自動実行されるが、フィードバックを早く
+上記はすべて`.github/workflows/ci.yml`でpush/PR時に自動実行されるが、フィードバックを早く
 得るためローカルでも変更直後に実行する。ただしCIが検証するのは配布経路（frontmatterの
-必須key・line budget・`install.sh`のsmoke test）だけであり、skillの技術的内容の正しさは
-自動化されていない。次は引き続き手動確認に代える。
+必須key・line budget・`install.sh --list`とskills/の整合・リンク切れ・`install.sh`のsmoke
+test）だけであり、skillの技術的内容の正しさは自動化されていない。次は引き続き手動確認に
+代える。
 
 - 変更した`SKILL.md`をfrontmatterから通読し、コードブロックのRustが構文的に妥当か目視確認する
   （`rustc --edition 2021 --crate-type lib -` にコード片を通して素早く構文チェックしてよい。
@@ -278,8 +283,9 @@ gh pr view <PR> --json mergeable,mergeStateStatus
 - `mergeable`が`CONFLICTING`の場合、force pushで上書きせず、mainを取り込んでから
   コンフリクトを解消し、§4〜§9を再実行する（コンフリクト解消で意図せず他人の変更を消さない）
 - `gh pr checks <PR>`（または`--watch`）で`.github/workflows/ci.yml`の全job
-  （`shellcheck` / `skill-frontmatter` / `install-smoke-test`）がgreenであることを確認して
-  からmergeする。落ちているjobがある場合、原因を修正せずmergeしない
+  （`shellcheck` / `skill-frontmatter` / `install-list-sync` / `link-check` /
+  `install-smoke-test`）がgreenであることを確認してからmergeする。落ちているjobがある場合、
+  原因を修正せずmergeしない
 - 上記いずれも未実行のままmergeしない
 
 PR本文には次を記載する。

--- a/scripts/check-install-list-sync.sh
+++ b/scripts/check-install-list-sync.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Verify `./install.sh --list` reports exactly the skills present under
+# skills/ — no directory missing from the listing, and no listed name
+# without a matching directory. `install.sh --list` currently derives its
+# output directly from `skills/*/`, so this is a regression guard against
+# that coupling breaking in the future (e.g. a hardcoded list creeping in),
+# not just a snapshot of today's state (docs/WORKFLOW.md §2, issue #2).
+#
+# Usage: ./scripts/check-install-list-sync.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$SCRIPT_DIR/.."
+SKILLS_DIR="$REPO_DIR/skills"
+
+status=0
+
+dir_names="$(cd "$SKILLS_DIR" && ls -d */ | sed 's#/$##' | sort)"
+
+# First whitespace-separated column of each "  <name>  <description>" line,
+# skipping the "Available skills:" header.
+list_names="$("$REPO_DIR/install.sh" --list | tail -n +2 | awk '{print $1}' | sort)"
+
+missing_from_list="$(comm -23 <(printf '%s\n' "$dir_names") <(printf '%s\n' "$list_names") || true)"
+if [[ -n "$missing_from_list" ]]; then
+  echo "FAIL: skill(s) under skills/ missing from 'install.sh --list':"
+  echo "$missing_from_list" | sed 's/^/  - /'
+  status=1
+fi
+
+missing_dir="$(comm -13 <(printf '%s\n' "$dir_names") <(printf '%s\n' "$list_names") || true)"
+if [[ -n "$missing_dir" ]]; then
+  echo "FAIL: 'install.sh --list' names skill(s) with no matching skills/ directory:"
+  echo "$missing_dir" | sed 's/^/  - /'
+  status=1
+fi
+
+if [[ $status -eq 0 ]]; then
+  count="$(printf '%s\n' "$dir_names" | grep -c .)"
+  echo "OK: install.sh --list matches skills/ ($count skill(s))"
+fi
+
+exit "$status"

--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Verify cross-references stay valid across skills/*/SKILL.md (and any
+# skills/*/references/*.md), README.md, and docs/*.md:
+#   - relative Markdown links `[text](target)` resolve to an existing file
+#     or directory (relative to the linking file); external links
+#     (http(s)://, mailto:) and pure in-page anchors (#foo) are skipped,
+#     and a trailing #fragment on a path target is stripped before checking
+#   - `[[name]]` references resolve to an existing skills/<name>/ directory
+#     (a forward-looking check: no skill currently uses this form)
+#
+# Deliberately does NOT flag bare-word mentions of skill names in prose
+# (e.g. "rust-patterns", "rust-analyzer") — those legitimately reference
+# skills/tools that live outside this repo (docs/PLAN.md delineation
+# table) or external tooling, and flagging them would be a false positive.
+# A skill referencing a not-yet-built sibling skill by bare name is a
+# distinct, harder-to-mechanize defect class; catch it with
+# `/skill-stocktake`, not this script (docs/WORKFLOW.md §4.2).
+#
+# Usage: ./scripts/check-links.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$SCRIPT_DIR/.."
+
+status=0
+
+check_file() {
+  local file="$1"
+  local dir
+  dir="$(dirname "$file")"
+
+  # Markdown links: [text](target)
+  while IFS= read -r match; do
+    [[ -z "$match" ]] && continue
+    target="${match#*](}"
+    target="${target%)}"
+    case "$target" in
+      http://*|https://*|mailto:*|\#*) continue ;;
+    esac
+    target="${target%%#*}"
+    [[ -z "$target" ]] && continue
+    if [[ ! -e "$dir/$target" ]]; then
+      echo "FAIL: $file — link target not found: $target"
+      status=1
+    fi
+  done < <(grep -oE '\[[^]]*\]\([^)]+\)' "$file" || true)
+
+  # [[name]] references — must match an existing skills/<name>/ directory.
+  while IFS= read -r name; do
+    [[ -z "$name" ]] && continue
+    if [[ ! -d "$REPO_DIR/skills/$name" ]]; then
+      echo "FAIL: $file — [[$name]] does not match any skills/$name/ directory"
+      status=1
+    fi
+  done < <(grep -oE '\[\[[a-zA-Z0-9_-]+\]\]' "$file" | sed -E 's/^\[\[//; s/\]\]$//' || true)
+}
+
+while IFS= read -r -d '' file; do
+  check_file "$file"
+done < <(find "$REPO_DIR/skills" -name '*.md' -print0)
+
+check_file "$REPO_DIR/README.md"
+
+while IFS= read -r -d '' file; do
+  check_file "$file"
+done < <(find "$REPO_DIR/docs" -maxdepth 1 -name '*.md' -print0)
+
+if [[ $status -eq 0 ]]; then
+  echo "OK: no broken relative links or [[name]] references found"
+fi
+
+exit "$status"

--- a/scripts/check-skill-frontmatter.sh
+++ b/scripts/check-skill-frontmatter.sh
@@ -40,6 +40,16 @@ for skill_md in "$SKILLS_DIR"/*/SKILL.md; do
     status=1
   fi
 
+  # description: is an unquoted YAML plain scalar, so a colon immediately
+  # followed by a space ends the value early no matter where it appears
+  # (backticks included) — this previously broke the harness's own
+  # frontmatter parser (docs/PLAN.md Status log, rust-pinning defect).
+  fm_desc="$(printf '%s\n' "$frontmatter" | sed -n 's/^description: *//p' | head -1)"
+  if [[ "$fm_desc" == *": "* ]]; then
+    echo "FAIL: $skill_md — description contains ': ' (colon+space), which truncates an unquoted YAML value — rewrite to avoid it (docs/WORKFLOW.md §4.2)"
+    status=1
+  fi
+
   lines="$(wc -l < "$skill_md" | tr -d ' ')"
   if (( lines > MAX_LINES )); then
     echo "FAIL: $skill_md — $lines lines exceeds the ${MAX_LINES}-line budget (docs/WORKFLOW.md §1)"


### PR DESCRIPTION
## Motivation
Closes #1, #2, #3.

## What changed
- **#1 — `skill-frontmatter` job**: `scripts/check-skill-frontmatter.sh` already checked for missing `name`/`description`/`source` keys, but never caught the actual mechanism behind the past `rust-pinning` defect (docs/PLAN.md Status log) — an unquoted YAML `description:` value truncates at any `: ` (colon+space), not just inside backticks. Broadened the check accordingly; verified against a synthetic regression (added `: ` outside backticks) that it now fails.
- **#2 — new `install-list-sync` job**: `scripts/check-install-list-sync.sh` diffs `install.sh --list` output against `skills/*/` directories. Note: `install.sh`'s `--list` already derives its output from the same glob, so under today's code this check is a regression guard against that coupling breaking in the future, not something that can find a live bug right now — flagged as such in the script comment and PLAN.md.
- **#3 — new `link-check` job**: `scripts/check-links.sh` verifies relative Markdown links and `[[name]]`-style refs across `skills/**/*.md`, `README.md`, `docs/*.md` resolve to real files/directories. External links, mailto:, and in-page anchors are skipped; a trailing `#fragment` on a path target is stripped before checking. Deliberately does **not** flag bare-word skill-name mentions in prose (`rust-patterns`, `rust-analyzer`, etc.) — those are legitimate references to things outside this repo (see docs/PLAN.md delineation table); a dangling bare reference to a not-yet-built skill stays a `/skill-stocktake` concern per docs/WORKFLOW.md §4.2.
- `shellcheck` job widened to `install.sh scripts/*.sh`; both new scripts pass at `--severity=warning`.
- Docs synced: `docs/WORKFLOW.md` §4.2 (validation table), §5/§7 (local quality gate commands), §9.2 (CI job list before merge); `docs/PLAN.md` Status log.

## Non-scope
No skill content, `source:` pins, delineation table, or `skills/` ↔ `.claude/skills/` symlink structure changed.

## Planning & review
Per docs/WORKFLOW.md §2.1, drafted an implementation plan and had a read-only `architect` subagent review it before implementation. Its findings were incorporated: the description check was broadened from "backtick spans only" to "any `: ` in an unquoted value" (the backtick framing wouldn't have caught the actual failure mode); the link checker was fixed to accept directory targets and strip URL fragments; issue #2's script was kept to its literal scope (install.sh --list vs skills/) rather than expanded to README-table checking, which would have been scope beyond what was asked; shellcheck coverage and doc-sync gaps (§4.2) were added.

## Verification
```
git diff --check
./scripts/check-skill-frontmatter.sh
./scripts/check-install-list-sync.sh
./scripts/check-links.sh
shellcheck --severity=warning install.sh scripts/*.sh
```
All pass locally. Each new/changed check was also manually verified to *detect* its target failure mode using a scratch copy outside the repo (a synthetic `: `-in-description regression, and a synthetic broken link + missing `[[name]]` target) before being confirmed clean against the real repo content.

`install.sh` itself was not modified, so the §5 manual install smoke test was not re-run; `install-smoke-test` CI job is unaffected.

## Not yet verified
- CI itself (this PR) — will check `gh pr checks` once it runs.
- No code-review subagent pass yet — will run before merge per §9.1.