### PR TITLE
docs: add bug-discovery workflow to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,3 +91,17 @@ gates in `docs/WORKFLOW.md`, not a unit-test suite.
 - Never report a task as complete without running the relevant check command and showing
   output.
 - Do not rely on your own summary as proof — the command output is the source of truth.
+
+## 6. Bug Discovery During Other Work
+
+**If you find a bug while doing something else, don't silently fix-and-move-on and don't let it
+block the current task.**
+
+When a bug turns up incidentally (not the thing you were asked to fix):
+1. Search the codebase for similar patterns that could have the same defect (e.g. same
+   copy-pasted logic, the same upstream source reused across multiple skills, the same helper
+   misused elsewhere).
+2. File a GitHub Issue (`gh issue create`) describing the bug, the affected location(s), and any
+   similar patterns found in step 1 — even the ones you didn't confirm are broken.
+3. Continue the original task. Only fix the bug inline if it blocks that task or the user asks
+   for it directly — otherwise let the issue track it, per [Surgical Changes](#3-surgical-changes).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,8 +100,13 @@ block the current task.**
 When a bug turns up incidentally (not the thing you were asked to fix):
 1. Search the codebase for similar patterns that could have the same defect (e.g. same
    copy-pasted logic, the same upstream source reused across multiple skills, the same helper
-   misused elsewhere).
-2. File a GitHub Issue (`gh issue create`) describing the bug, the affected location(s), and any
-   similar patterns found in step 1 — even the ones you didn't confirm are broken.
-3. Continue the original task. Only fix the bug inline if it blocks that task or the user asks
+   misused elsewhere). Only list a similar pattern as affected if you've actually confirmed it's
+   broken (traced the logic or reproduced it) — flag unconfirmed lookalikes separately as
+   "needs verification," don't report them as bugs.
+2. Search existing GitHub Issues (open and closed — `gh issue list --state all --search ...`) for
+   a report that already covers this. If one exists, update it (`gh issue comment`) instead of
+   filing a duplicate.
+3. Before filing a new Issue, get the user's explicit go-ahead — surface what you found and ask,
+   don't `gh issue create` unilaterally.
+4. Continue the original task. Only fix the bug inline if it blocks that task or the user asks
    for it directly — otherwise let the issue track it, per [Surgical Changes](#3-surgical-changes).


### PR DESCRIPTION
## 概要
作業中に本来の依頼とは別のバグを見つけた場合の対応方針を CLAUDE.md に追記。

## 変更内容
- 類似パターンをコードベース内で調査するステップを追加（確認できたものだけを対象、未確認は「要検証」として区別）
- GitHub Issue 起票前に既存のオープン／クローズ済み Issue を検索し、重複があれば既存Issueを更新する手順を追加
- 新規 Issue 作成前にユーザーの明示的な承認を得る手順を追加
- 元のタスクをブロックしない限りその場で直さず Issue に任せる方針を明記（既存の Surgical Changes 原則と整合）

Codex アドバーサリアルレビューで「無制御な Issue 作成による重複・未検証報告」の懸念が指摘され、それを踏まえて修正済み。

## Test plan
- [x] `git diff --check`（空白系の問題なし）
- ドキュメントのみの変更のため、他の検証コマンドは対象外