### PR TITLE
feat: add markdown lint CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,19 @@ jobs:
       - name: Check relative links and [[name]] references
         run: ./scripts/check-links.sh
 
+  markdown-lint:
+    name: Markdown lint (heading structure, code fence language)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run markdownlint-cli2
+        uses: DavidAnson/markdownlint-cli2-action@v24
+        with:
+          globs: |
+            skills/**/*.md
+            docs/**/*.md
+            README.md
+
   install-smoke-test:
     name: install.sh smoke test
     runs-on: ubuntu-latest

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,32 @@
+// markdownlint-cli2 config for this repo.
+//
+// Scope: skills/, docs/, README.md (see .github/workflows/ci.yml for the exact globs run
+// in CI). ref/comprehensive-rust/ is gitignored, vendored upstream content and is never
+// linted here.
+//
+// Rule selection is deliberately narrow — this is a content repo whose prose is adapted
+// from an external, CC-BY-4.0 upstream course, so we don't want a full default ruleset
+// (line-length, etc.) forcing rewrites of upstream-derived wording. Per issue #4, the goal
+// is a minimal, mechanical quality bar: heading structure and fenced-code language tags.
+// See docs/WORKFLOW.md §7 for how this fits the rest of the quality gate.
+{
+  "config": {
+    "default": false,
+    "MD001": true, // heading levels increment by one
+    "MD003": { "style": "atx" }, // consistent ATX (`#`) heading style
+    "MD009": true, // no trailing spaces
+    "MD010": true, // no hard tabs
+    "MD018": true, // no missing space after `#` in ATX heading
+    "MD019": true, // no multiple spaces after `#` in ATX heading
+    "MD022": true, // headings surrounded by blank lines
+    "MD023": true, // headings start at the beginning of the line
+    "MD024": { "siblings_only": true }, // no duplicate heading text under the same parent
+    "MD025": true, // single top-level (H1) heading per file
+    "MD026": true, // no trailing punctuation in heading text
+    "MD040": true, // fenced code blocks must specify a language
+    "MD041": false, // off: SKILL.md files start with YAML frontmatter, not an H1
+    "MD047": true // files end with a single trailing newline
+  },
+  "globs": ["skills/**/*.md", "docs/**/*.md", "README.md"],
+  "ignores": ["ref/**"]
+}

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ rm -rf ~/.claude/skills/rust-api-design            # or under <project>/.claude/
 
 ## Repository layout
 
-```
+```text
 rust-skills-comprehensive/
 ├── install.sh              # installer (see above)
 ├── skills/                 # the 11 skills — canonical source, this is what install.sh copies from

--- a/docs/FILE_MAP.md
+++ b/docs/FILE_MAP.md
@@ -7,12 +7,14 @@ driven by `SUMMARY.md` (the mdBook table of contents — treat it as the authori
 Legend: 📄 file count in subtree · each section lists its own `SUMMARY.md` anchor file first.
 
 ## 0. Front matter / meta
+
 - `index.md`, `README.md`, `running-the-course.md` (+`course-structure.md`, `keyboard-shortcuts.md`, `translations.md`)
 - `cargo.md` (+`rust-ecosystem.md`, `code-samples.md`, `running-locally.md`)
 - `thanks.md`, `glossary.md`, `other-resources.md`, `credits.md`
 - `welcome-day-{1,2,3,4}.md`, `welcome-day-{1,2,3,4}-afternoon.md` — day dividers, mostly agenda text, low reuse value for skills.
 
 ## 1. Core Language — Day 1–2 (📄 ~100 files)
+
 Fundamentals that almost every Rust skill will want to reference.
 
 | Topic | Anchor | Children |
@@ -40,6 +42,7 @@ Fundamentals that almost every Rust skill will want to reference.
 | Unsafe Rust (intro-level) | `unsafe-rust.md` | `unsafe-rust/{unsafe,dereferencing,mutable-static,unions,unsafe-traits,exercise,solution}.md`, `unsafe-functions.md`+`unsafe-functions/{rust,extern-c,calling}.md` |
 
 ## 2. Concurrency — Day-length module (📄 43 files)
+
 - `concurrency/welcome.md`, `welcome-async.md`
 - Threads: `threads.md` + `threads/{plain,scoped}.md`
 - Channels: `channels.md` + `channels/{senders-receivers,unbounded,bounded}.md`
@@ -52,6 +55,7 @@ Fundamentals that almost every Rust skill will want to reference.
 - Async exercises: `async-exercises.md` + `async-exercises/{afternoon,dining-philosophers,chat-app,solutions}.md`
 
 ## 3. Idiomatic Rust — largest single module (📄 109 files)
+
 - `idiomatic/welcome.md`
 - **Foundations of API Design** `idiomatic/foundations-api-design.md`
   - Meaningful Doc Comments: `meaningful-doc-comments.md` + 7 sub-pages (who-are-you-writing-for, library-vs-application-docs, anatomy-of-a-doc-comment, name-drop-signpost, avoid-redundancy, what-isnt-docs, what-why-not-how-where, exercise)
@@ -65,6 +69,7 @@ Fundamentals that almost every Rust skill will want to reference.
   - From OOP to Rust (+15: inheritance, why-no-inheritance, switch-perspective, supertraits, composition, dynamic-dispatch/{dyn-trait,dyn-compatible,dyn-vs-generics,limits,heterogeneous,any-trait,pitfalls}, sealed-traits, sealing-with-enums, sticking-with-traits, problem-solving)
 
 ## 4. Unsafe Deep Dive — advanced module (📄 83 files)
+
 - `unsafe-deep-dive/{welcome,setup}.md`
 - Introduction (+15: definition, purpose, two-roles, warm-up/*, characteristics-of-unsafe-rust/*, responsibility-shift, impact-on-workflow, may_overflow)
 - Safety Preconditions (+8: common-preconditions, getter, semantic-preconditions, u8-to-bool, determining, references, defining, ascii)
@@ -75,14 +80,17 @@ Fundamentals that almost every Rust skill will want to reference.
 - FFI (+15, overlaps with §5): language-interop, strategies, type-safety, language-differences/*, abs, rand, c-library-example, cpp-library-example
 
 ## 5. Platform / Interop modules (own tracks, not part of the 4-day core)
+
 - **Android** (📄 48): setup, build-rules (binary/library), AIDL (birthday-service tutorial + 8 sub-steps, types + 5 sub-types), testing (googletest, mocking), logging, interoperability with C (+5), C++ (+13 incl. cxx bridge/genrules), Java.
 - **Chromium** (📄 30): setup, cargo-vs-chromium, policy, build-rules (+unsafe, depending, vscode, exercise), testing (+rust_gtest_interop, build-gn, import-macro, exercise), interoperability-with-cpp (+example-bindings, limitations-of-cxx, error-handling + qr/png examples, using-cxx-in-chromium, exercise), adding-third-party-crates (+11 sub-pages), bringing-it-together, solutions.
 - **Bare Metal** (📄 41): no_std (+minimal, alloc), microcontrollers (+mmio, pacs, hals, board-support, type-state, embedded-hal, probe-rs+debugging, other-projects), Application Processors `aps.md` (+entry-point, inline-assembly, mmio, uart+traits/using, better-uart+bitflags/registers/driver, safemmio/*, logging+using, exceptions, aarch64-rt+exceptions, other-projects), useful-crates (zerocopy, aarch64-paging, buddy_system_allocator, tinyvec, spin), android bare-metal (vmbase), exercises (morning/afternoon + compass/rtc + solutions).
 
 ## 6. Exercises (📄 12, cross-cutting)
+
 `exercises/bare-metal/*` and `exercises/chromium/*` hold exercise prompts + solutions that live outside their module's own directory — cross-reference when building any "exercises" skill.
 
 ## Rough size ranking (for prioritization)
+
 1. Idiomatic Rust — 109 files (deepest, most skill-worthy content: API design, type-system tricks, polymorphism)
 2. Unsafe Deep Dive — 83 files (advanced, narrow audience, high value for a dedicated "advanced unsafe" skill)
 3. Core Language Day 1–2 — ~100 files across 20 small topics (foundational, likely already partly covered by the existing `rust-patterns`/`rust-testing` skills)

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -57,6 +57,15 @@ are legitimate references to things outside this repo) — a dangling bare refer
 not-yet-built skill (the `rust-bare-metal` defect above) stays a `/skill-stocktake` concern,
 not a script one. `shellcheck` job widened to `scripts/*.sh`.
 
+**Markdown lint (2026-09-01, issue #4)**: added `.markdownlint-cli2.jsonc` and a `markdown-lint`
+CI job scoped to `skills/**/*.md`, `docs/**/*.md`, `README.md`. Rule selection is deliberately
+narrow (heading structure + `MD040` fenced-code-language) rather than the full default
+ruleset — this repo's prose is adapted from an external CC-BY-4.0 course, so line-length-style
+rules would force rewrites of upstream-derived wording for no content benefit. Fixed the small
+number of pre-existing violations this surfaced: missing blank lines after headings in
+`FILE_MAP.md`, and three unlabeled fenced code blocks (`PLAN.md`, `README.md`,
+`rust-ffi/SKILL.md`) tagged `text`.
+
 Source map: [`FILE_MAP.md`](./FILE_MAP.md). Goal: turn Google's Comprehensive Rust course into
 a set of Claude Code **skills** (`SKILL.md` + `references/`), each scoped tightly enough to
 load fast and stay focused, together covering the course's teaching value — not a transcription
@@ -248,7 +257,7 @@ standalone skills (exercises are eval input instead — see below).
 
 Because the course is CC-BY-4.0, every generated skill must include, in `SKILL.md`:
 
-```
+```text
 Adapted from Comprehensive Rust (https://google.github.io/comprehensive-rust/),
 © Google LLC, CC-BY-4.0. Code samples Apache-2.0. Source pin: 351fafa.
 ```

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -195,13 +195,15 @@ git diff --check                 # 空白・改行の混在を検出
 ./scripts/check-install-list-sync.sh
 ./scripts/check-links.sh
 shellcheck --severity=warning install.sh scripts/*.sh
+npx --yes markdownlint-cli2 --config .markdownlint-cli2.jsonc "skills/**/*.md" "docs/**/*.md" "README.md"
 ```
 
 上記はすべて`.github/workflows/ci.yml`でpush/PR時に自動実行されるが、フィードバックを早く
 得るためローカルでも変更直後に実行する。ただしCIが検証するのは配布経路（frontmatterの
 必須key・line budget・`install.sh --list`とskills/の整合・リンク切れ・`install.sh`のsmoke
-test）だけであり、skillの技術的内容の正しさは自動化されていない。次は引き続き手動確認に
-代える。
+test）と`skills/`・`docs/`・README.mdの最低限のMarkdown品質（見出し構造・コードフェンスの
+言語指定、`.markdownlint-cli2.jsonc`参照）だけであり、skillの技術的内容の正しさは自動化
+されていない。次は引き続き手動確認に代える。
 
 - 変更した`SKILL.md`をfrontmatterから通読し、コードブロックのRustが構文的に妥当か目視確認する
   （`rustc --edition 2021 --crate-type lib -` にコード片を通して素早く構文チェックしてよい。
@@ -284,7 +286,8 @@ gh pr view <PR> --json mergeable,mergeStateStatus
   コンフリクトを解消し、§4〜§9を再実行する（コンフリクト解消で意図せず他人の変更を消さない）
 - `gh pr checks <PR>`（または`--watch`）で`.github/workflows/ci.yml`の全job
   （`shellcheck` / `skill-frontmatter` / `install-list-sync` / `link-check` /
-  `install-smoke-test`）がgreenであることを確認してからmergeする。落ちているjobがある場合、
+  `markdown-lint` / `install-smoke-test`）がgreenであることを確認してからmergeする。
+  落ちているjobがある場合、
   原因を修正せずmergeしない
 - 上記いずれも未実行のままmergeしない
 

--- a/skills/rust-ffi/SKILL.md
+++ b/skills/rust-ffi/SKILL.md
@@ -21,7 +21,7 @@ other's functions directly — their type layouts, calling conventions, and runt
 don't agree. The practical path both directions go through is the **C ABI** as a lowest common
 denominator:
 
-```
+```text
 Rust  <----->  C ABI  <----->  C++
 ```
 


### PR DESCRIPTION
Closes #4.

## Motivation
Issue #4: mechanically guarantee a minimum documentation quality bar (heading structure,
fenced-code language tags) across `skills/`, `docs/`, and `README.md`.

## Changes
- `.markdownlint-cli2.jsonc`: a deliberately narrow rule set (not the full default ruleset —
  this repo's prose is adapted from an external CC-BY-4.0 course, so line-length-style rules
  would force rewrites of upstream-derived wording for no content benefit). Enables heading
  structure (`MD001`/`MD003`/`MD022`/`MD023`/`MD024`/`MD025`/`MD026`), fenced-code language
  (`MD040`), and a few mechanical hygiene rules (`MD009`/`MD010`/`MD018`/`MD019`/`MD047`).
- New `markdown-lint` CI job (`DavidAnson/markdownlint-cli2-action@v24`) scoped to
  `skills/**/*.md`, `docs/**/*.md`, `README.md`.
- Fixed the small number of pre-existing violations this surfaced: missing blank lines after
  headings in `docs/FILE_MAP.md` (8 spots), and 3 unlabeled fenced code blocks (`docs/PLAN.md`,
  `README.md`, `skills/rust-ffi/SKILL.md`) tagged `text`.
- Synced `docs/WORKFLOW.md` §7 (local quality-gate command list) and §9.2 (CI job list to
  check green before merge) and `docs/PLAN.md`'s Status section.

## Attribution / duplication / line-budget impact
None — no `SKILL.md` content changed beyond the one fenced-code-language tag in
`rust-ffi/SKILL.md` (no prose change, no `source:` pin change).

## Checks run (docs/WORKFLOW.md §7)
- `git diff --check` — clean
- `./scripts/check-skill-frontmatter.sh` — OK
- `./scripts/check-install-list-sync.sh` — OK
- `./scripts/check-links.sh` — OK
- `shellcheck --severity=warning install.sh scripts/*.sh` — clean
- `npx --yes markdownlint-cli2 --config .markdownlint-cli2.jsonc "skills/**/*.md" "docs/**/*.md" "README.md"` — 0 issues

## Not run
- `/skill-stocktake` — not applicable, no `SKILL.md` prose/description changed (only a code
  fence's language tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)