### PR TITLE
feat: add exercise-based skill eval suite and first pilot

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -40,8 +40,9 @@ themselves at the pinned commit. `LICENSE-CODE` (Apache-2.0) and `LICENSE-CONTEN
 vendor the upstream course's two license texts at the repo root.
 
 **Not yet done**: Phase 4 (routing block in `rust-patterns`, Day 1–2 gap-fill), Phase 5
-(platform skills — still gated on user confirmation), exercise-based eval against the course's
-own exercises/solutions.
+(platform skills — still gated on user confirmation). Exercise-based eval against the course's
+own exercises/solutions is now piloted for 2 exercises — see the entry below and
+`docs/eval/README.md` — with several mapped exercises still deferred to a follow-up.
 
 **CI hardening (2026-08-31, issues #1–#3)**: closed a real gap in `skill-frontmatter` —
 the script checked presence of frontmatter keys but never caught the actual `rust-pinning`
@@ -65,6 +66,30 @@ rules would force rewrites of upstream-derived wording for no content benefit. F
 number of pre-existing violations this surfaced: missing blank lines after headings in
 `FILE_MAP.md`, and three unlabeled fenced code blocks (`PLAN.md`, `README.md`,
 `rust-ffi/SKILL.md`) tagged `text`.
+
+**Exercise-based eval (2026-09-01, issue #6)**: added `docs/eval/` — a mapping of upstream
+`exercise.md`/`solution.md` coding-exercise pairs to the skill(s) covering them, a
+solve-blind/judge-with-solution methodology, and a report format
+(`docs/eval/README.md`). Only 3 of the 11 skills have upstream chapters that ship a
+self-contained *coding* exercise with a reference solution (`rust-ownership-and-lifetimes`,
+`rust-unsafe-fundamentals`, plus the shared-`solutions.md` shape covering
+`rust-concurrency-sync`/`rust-async`) — the rest of this skill set derives from
+worked-example/prose pages or discussion-only exercises with no code solution to compare
+against, so there's nothing this method can run for them; that's not a gap in the eval, see
+`docs/eval/README.md`'s mapping table. Ran a first pilot
+(`docs/eval/results/2026-09-01-pilot.md`): 2 exercises against `rust-ownership-and-lifetimes`
+("Wizard's Inventory" from `borrowing/`, "Protobuf Parsing" from `lifetimes/`), each solved by
+a fresh subagent given only the skill + exercise skeleton (no `solution.md`), then judged
+against the real `solution.md` by this session. Both **PASS** — the solver's technique matched
+`solution.md`'s, and each solver's own report cited the specific skill section that led it
+there. Deferred to a follow-up: `unsafe-rust/exercise.md` (no missing dependency — its
+`Cargo.toml` already has what it needs — left out purely for the setup time of its larger
+skeleton; also straddles `rust-unsafe-fundamentals`/`rust-ffi` rather than cleanly mapping to
+one skill) and the `concurrency/*` exercises (need their shared `solutions.md` split
+per-exercise before they fit the Assemble step). Not wired into `.github/workflows/ci.yml` —
+an LLM-driven solve/judge step doesn't fit the deterministic jobs there;
+`scripts/check-eval-map.sh` is a local-only sanity check that the mapping's literal upstream
+paths still exist, not a CI job.
 
 Source map: [`FILE_MAP.md`](./FILE_MAP.md). Goal: turn Google's Comprehensive Rust course into
 a set of Claude Code **skills** (`SKILL.md` + `references/`), each scoped tightly enough to

--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -52,7 +52,7 @@ code solution — several `idiomatic/**` exercises are the latter and are exclud
 |---|---|---|---|
 | `rust-ownership-and-lifetimes` | `borrowing/exercise.md` ("Wizard's Inventory") | standalone: `exercise.rs` has `// ANCHOR: setup/main/tests`, `solution.md` includes `// ANCHOR: solution` (the whole file) | **Run** — see `results/2026-09-01-pilot.md` |
 | `rust-ownership-and-lifetimes` | `lifetimes/exercise.md` ("Protobuf Parsing") | standalone, same ANCHOR structure, larger (~200 lines) | **Run** — see `results/2026-09-01-pilot.md` |
-| `rust-unsafe-fundamentals` | `unsafe-rust/exercise.md` ("Safe FFI Wrapper") | standalone, but the *content* is FFI (`CStr`/`OsStr`, wrapping `libc` calls) more than "everyday unsafe" — a good candidate to run with **both** `rust-unsafe-fundamentals` and `rust-ffi` loaded together next time; needs the `libc` crate as a dev-dependency | Mapped, not yet run — see Limitations |
+| `rust-unsafe-fundamentals` | `unsafe-rust/exercise.md` ("Safe FFI Wrapper") | standalone (its `Cargo.toml` already declares everything it needs — `tempfile` as a dev-dependency, no `libc` crate involved; the C bindings are hand-declared via `unsafe extern "C"`, with `#[cfg(target_os = "macos")]` branches already present), but the *content* is FFI (`CStr`/`OsStr`, wrapping raw `opendir`/`readdir`/`closedir` calls) more than "everyday unsafe" — a good candidate to run with **both** `rust-unsafe-fundamentals` and `rust-ffi` loaded together next time | Mapped, not yet run — see Limitations |
 | `rust-concurrency-sync` | `concurrency/sync-exercises/{dining-philosophers,link-checker}.md` | prompt page + starter `.rs` + shared `solutions.md` (multiple solutions in one file, `## Dining Philosophers` / `## Link Checker` headings) | Mapped, not yet run |
 | `rust-async` | `concurrency/async-exercises/{dining-philosophers,chat-app}.md` | same shared-`solutions.md` shape as above (`## Dining Philosophers — Async` / `## Broadcast Chat Application`) | Mapped, not yet run |
 | `rust-api-design` | `idiomatic/foundations-api-design/**/exercise.md` | class-discussion prompt (fill-in-the-blank naming, "ask the class" narrative) — **no code solution to compare against** | **Excluded** — not this eval's shape |
@@ -81,10 +81,13 @@ exercise wasn't run to completion>
 ## Limitations of this pass
 
 - Only 2 of the mapped exercises were actually run end-to-end (compiled + tested) in the pilot;
-  the rest are mapped but deferred (`unsafe-rust/exercise.md` needs a `libc` dev-dependency and
-  network-independent verification of directory-listing behavior; the `concurrency/*`
-  exercises need the shared-`solutions.md` file split per-exercise before they fit the
-  Assemble step cleanly — worth a follow-up rather than blocking this issue).
+  the rest are mapped but deferred (`unsafe-rust/exercise.md` doesn't need any extra
+  dependency — its `Cargo.toml` already has what the exercise needs — it was left out of this
+  pilot purely for time: assembling its larger skeleton, and deciding whether to run it with
+  one skill or both `rust-unsafe-fundamentals` and `rust-ffi` loaded together, is more setup
+  than the other two; the `concurrency/*` exercises need the shared-`solutions.md` file split
+  per-exercise before they fit the Assemble step cleanly — worth a follow-up rather than
+  blocking this issue).
 - This eval only covers skills whose upstream chapter shipped a self-contained coding
   exercise. Most of this skill set's advanced-topic skills (typestate, pinning, unsafe
   soundness, FFI, newtype/RAII, polymorphism) come from `idiomatic/leveraging-the-type-system`,

--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -1,0 +1,94 @@
+# Exercise-based skill eval
+
+**Issue:** [#6](https://github.com/takurot/rust-skills-comprehensive/issues/6) — does loading
+a skill actually get you to the idiom the course teaches, not just a `/skill-stocktake`-style
+description check?
+
+`/skill-stocktake` verifies a skill's `description:` triggers correctly and doesn't duplicate a
+neighbor. It says nothing about whether the skill's *content* actually steers someone toward
+the course's idiom when they use it to solve a real problem. This eval closes that gap for the
+subset of upstream chapters that ship a self-contained coding exercise with a reference
+solution.
+
+## Method
+
+Three roles, kept separate so the model that *solves* the exercise never sees the official
+solution (a solver that has already read `solution.md` isn't testing whether the skill's
+guidance was sufficient — it's testing recall):
+
+1. **Assemble** — take an exercise's student-facing skeleton (the exercise page's code block,
+   with `todo!()`s) and the one skill under test. No `solution.md` content goes into this step.
+2. **Solve** — a fresh agent (no prior context, no access to `solution.md`) is given only the
+   skeleton and the skill's `SKILL.md`, and asked to implement it — compiling and running any
+   provided tests where the exercise has them.
+3. **Judge** — a separate pass (this can be the orchestrating session, since by this point
+   seeing the solution is exactly its job) compares the solver's approach against
+   `solution.md`, specifically for the *technique* the skill is supposed to teach (not just
+   "did the tests pass" — a solution can pass tests via a different, less idiomatic route).
+   Records a verdict below.
+
+Run manually per exercise for now (see `docs/PLAN.md`'s note that this is designed to fold into
+CI later, not wired in yet — an LLM-driven step doesn't fit the deterministic jobs in
+`.github/workflows/ci.yml` as-is). `ref/comprehensive-rust/` (gitignored, see repo root
+`.gitignore`) must be cloned at the pinned commit — see `docs/WORKFLOW.md` §3.3 — before
+assembling any exercise.
+
+### Verdict scale
+
+| Verdict | Meaning |
+|---|---|
+| PASS | Solver's approach uses the same technique `solution.md` uses for the point the skill teaches; tests (if any) pass. |
+| PARTIAL | Solves the exercise and tests pass, but via a materially different technique than `solution.md`'s (not necessarily wrong — but doesn't demonstrate the skill's guidance was what drove the choice). |
+| FAIL | Doesn't compile, tests fail, or hits the exact pitfall the skill exists to prevent. |
+
+## Exercise → skill mapping
+
+Built by cross-referencing each skill's `source:` frontmatter paths (`docs/PLAN.md`'s catalog)
+against `ref/comprehensive-rust/src/**` for `exercise.md`/`exercise.rs` + `solution.md` (or
+`solutions.md`) triples that are actual coding exercises (not class-discussion prompts with no
+code solution — several `idiomatic/**` exercises are the latter and are excluded below).
+
+| Skill | Upstream exercise | Format | Status |
+|---|---|---|---|
+| `rust-ownership-and-lifetimes` | `borrowing/exercise.md` ("Wizard's Inventory") | standalone: `exercise.rs` has `// ANCHOR: setup/main/tests`, `solution.md` includes `// ANCHOR: solution` (the whole file) | **Run** — see `results/2026-09-01-pilot.md` |
+| `rust-ownership-and-lifetimes` | `lifetimes/exercise.md` ("Protobuf Parsing") | standalone, same ANCHOR structure, larger (~200 lines) | **Run** — see `results/2026-09-01-pilot.md` |
+| `rust-unsafe-fundamentals` | `unsafe-rust/exercise.md` ("Safe FFI Wrapper") | standalone, but the *content* is FFI (`CStr`/`OsStr`, wrapping `libc` calls) more than "everyday unsafe" — a good candidate to run with **both** `rust-unsafe-fundamentals` and `rust-ffi` loaded together next time; needs the `libc` crate as a dev-dependency | Mapped, not yet run — see Limitations |
+| `rust-concurrency-sync` | `concurrency/sync-exercises/{dining-philosophers,link-checker}.md` | prompt page + starter `.rs` + shared `solutions.md` (multiple solutions in one file, `## Dining Philosophers` / `## Link Checker` headings) | Mapped, not yet run |
+| `rust-async` | `concurrency/async-exercises/{dining-philosophers,chat-app}.md` | same shared-`solutions.md` shape as above (`## Dining Philosophers — Async` / `## Broadcast Chat Application`) | Mapped, not yet run |
+| `rust-api-design` | `idiomatic/foundations-api-design/**/exercise.md` | class-discussion prompt (fill-in-the-blank naming, "ask the class" narrative) — **no code solution to compare against** | **Excluded** — not this eval's shape |
+| `rust-newtype-and-raii`, `rust-typestate-and-tokens`, `rust-polymorphism`, `rust-unsafe-soundness`, `rust-pinning`, `rust-ffi` | — | — | **No `exercise.md`/`solution.md` pair exists under these skills' source paths upstream** (worked-example/prose pages only) — excluded, not a gap in this eval |
+
+## Report format
+
+Each run's results live in `docs/eval/results/<date>-<label>.md` with one section per exercise:
+
+```markdown
+## <skill> — <exercise title> (<upstream path>)
+
+**Verdict:** PASS | PARTIAL | FAIL
+
+**Solver setup:** <how the solver was invoked — fresh subagent, model, what it was given>
+
+**Technique comparison:** <what `solution.md` does for the point the skill teaches, vs. what
+the solver did — cite the exact skill section, if any, that should have (or did) inform it>
+
+**Test/compile result:** <cargo test output summary, or "not compiled — reason", if the
+exercise wasn't run to completion>
+```
+
+`docs/PLAN.md`'s Status section links to the latest run.
+
+## Limitations of this pass
+
+- Only 2 of the mapped exercises were actually run end-to-end (compiled + tested) in the pilot;
+  the rest are mapped but deferred (`unsafe-rust/exercise.md` needs a `libc` dev-dependency and
+  network-independent verification of directory-listing behavior; the `concurrency/*`
+  exercises need the shared-`solutions.md` file split per-exercise before they fit the
+  Assemble step cleanly — worth a follow-up rather than blocking this issue).
+- This eval only covers skills whose upstream chapter shipped a self-contained coding
+  exercise. Most of this skill set's advanced-topic skills (typestate, pinning, unsafe
+  soundness, FFI, newtype/RAII, polymorphism) come from `idiomatic/leveraging-the-type-system`,
+  `idiomatic/polymorphism`, and `unsafe-deep-dive/{pinning,ffi,...}` pages that are
+  worked-example prose, not student exercises — there's nothing to run this method against for
+  those skills. Their effectiveness stays a `/skill-stocktake` (trigger + non-duplication)
+  concern, not this one.

--- a/docs/eval/results/2026-09-01-pilot.md
+++ b/docs/eval/results/2026-09-01-pilot.md
@@ -1,0 +1,67 @@
+# Pilot run — 2026-09-01
+
+First run of the exercise-based eval (issue #6). Solver step for each exercise below was a
+fresh subagent given only the exercise skeleton and the named `SKILL.md` — no access to
+`solution.md`. Judge step (this section) was written by the orchestrating session, which had
+already read the upstream `solution.md` while building `docs/eval/README.md`'s mapping.
+
+## `rust-ownership-and-lifetimes` — "Wizard's Inventory" (`borrowing/exercise.md`)
+
+**Verdict:** PASS
+
+**Solver setup:** Fresh `general-purpose` subagent, given the exercise skeleton (struct
+definitions, `todo!()`-marked `add_spell`/`cast_spell`, `main`, and the 5-test `#[cfg(test)]`
+module) plus the full text of `skills/rust-ownership-and-lifetimes/SKILL.md`. Asked to
+implement, compile, and get all 5 tests passing via `cargo test`.
+
+**Technique comparison:** `solution.md` locates the spell first (loop collecting an
+`Option<usize>` index), *then* takes `&mut self.spells[idx]` for the mana/uses update, and
+calls `self.spells.remove(idx)` only after that reference's last use — never holding a live
+reference into the `Vec` across the `.remove()` call. The solver's solution does the same
+thing: `self.spells.iter().position(...)` to get an owned `index: usize`, then
+`&mut self.spells[index]`, with `.remove(index)` again only after the reference's last use.
+Functionally identical technique (`position()` instead of a manual indexed loop — a more
+idiomatic equivalent, not a different approach). The solver's own report cites the skill's
+"fields borrow independently" note (for why `self.mana -=` and `spell.uses -=` can coexist)
+and the "index/handle instead of reference" + iterator-invalidation row of the triage table
+(for why it never held `spell` live across `.remove()`) — i.e. the match wasn't a coincidence,
+the skill's stated guidance is what the solver's own reasoning points to.
+
+**Test/compile result:** `cargo test` — all 5 tests (`test_add_spell`, `test_cast_spell`,
+`test_cast_spell_insufficient_mana`, `test_cast_spell_not_found`, `test_cast_spell_removal`)
+passed.
+
+## `rust-ownership-and-lifetimes` — "Protobuf Parsing" (`lifetimes/exercise.md`)
+
+**Verdict:** PASS
+
+**Solver setup:** Fresh `general-purpose` subagent, given the exercise skeleton (all
+preliminaries provided; `parse_field`'s match body and `ProtoMessage for Person`/`PhoneNumber`
+left as `todo!()`) plus the full text of `skills/rust-ownership-and-lifetimes/SKILL.md`. Asked
+to implement, compile, and get all 5 tests passing via `cargo test`.
+
+**Technique comparison:** `solution.md`'s `parse_field` and both `ProtoMessage` impls (embedded
+in `exercise.rs`'s `// ANCHOR: solution` block) are structurally identical to the solver's
+output: same `match wire_type` arms (`Varint` → `parse_varint` + wrap; `Len` → `parse_varint`
+for the length, `split_at`, wrap), same field-number `match` in both `add_field`
+implementations, same use of `parse_message(field.value.as_bytes())` for the recursive
+`PhoneNumber` sub-message. The point this exercise actually tests — whether a single lifetime
+parameter `'a` threaded from the top-level input slice through `Field`/`FieldValue`/`Person`/
+`PhoneNumber` is correct, with no cloning — is exactly what the skill's "Lifetimes in structs"
+and "Choosing a data-sharing strategy" sections argue for (own by default; borrow only for a
+"short-lived, zero-copy view" like a parser's token/slice, which is precisely this exercise's
+shape). The solver's own report explicitly reasons from those two sections rather than just
+type-checking its way to the right lifetime.
+
+**Test/compile result:** `cargo test` — all 5 tests (`test_id`, `test_name`,
+`test_just_person`, `test_phone`, `test_full_person`) passed.
+
+## Summary
+
+2/2 run exercises PASS. Both solver reports independently cited the specific skill sections
+that match the technique used in `solution.md` (not just "it compiled and passed") —
+`rust-ownership-and-lifetimes`'s triage table and "Choosing a data-sharing strategy" section
+appear to be doing the job they're meant to do for these two exercises. This is a 2-exercise,
+1-skill pilot; see `docs/eval/README.md`'s Limitations section for what's mapped but not yet
+run (`rust-unsafe-fundamentals`/`rust-ffi` via `unsafe-rust/exercise.md`, and the
+`rust-concurrency-sync`/`rust-async` shared-`solutions.md` exercises).

--- a/scripts/check-eval-map.sh
+++ b/scripts/check-eval-map.sh
@@ -21,6 +21,11 @@ if [[ ! -d "$REF_DIR" ]]; then
   exit 0
 fi
 
+if [[ ! -f "$MAP_FILE" ]]; then
+  echo "FAIL: $MAP_FILE not found" >&2
+  exit 1
+fi
+
 status=0
 
 # Pull every backtick-quoted path fragment that looks like an upstream exercise/solution

--- a/scripts/check-eval-map.sh
+++ b/scripts/check-eval-map.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Verify every upstream path listed in docs/eval/README.md's exercise->skill mapping table
+# still exists in the vendored course checkout. This is a *local-only* sanity check — it is
+# NOT wired into .github/workflows/ci.yml because ref/comprehensive-rust/ is gitignored and
+# not present in CI (see docs/WORKFLOW.md §3.3, §6).
+#
+# Run this after re-pinning ref/comprehensive-rust to a newer upstream commit, to catch a
+# renamed/removed exercise before docs/eval/README.md's mapping goes stale silently.
+#
+# Usage: ./scripts/check-eval-map.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$SCRIPT_DIR/.."
+REF_DIR="$REPO_DIR/ref/comprehensive-rust/src"
+MAP_FILE="$REPO_DIR/docs/eval/README.md"
+
+if [[ ! -d "$REF_DIR" ]]; then
+  echo "SKIP: $REF_DIR not present — clone ref/comprehensive-rust first (docs/WORKFLOW.md §3.3)" >&2
+  exit 0
+fi
+
+status=0
+
+# Pull every backtick-quoted path fragment that looks like an upstream exercise/solution
+# reference (contains "exercise" or "solution") out of the mapping table's second column.
+# Only literal single-file paths are checked — brace-expansion (`{a,b}.md`) and glob
+# (`**/exercise.md`) entries in the table are intentionally skipped rather than
+# mis-validated; those rows stay a manual-review concern.
+while IFS= read -r path; do
+  [[ -z "$path" ]] && continue
+  # Strip a trailing directory-glob suffix like "**/exercise.md" isn't used here, but handle
+  # a leading "{a,b}" brace group defensively by taking it as literal (none currently occur).
+  if [[ ! -e "$REF_DIR/$path" ]]; then
+    echo "FAIL: docs/eval/README.md references $path — not found under $REF_DIR"
+    status=1
+  fi
+done < <(grep -oE '`[a-zA-Z0-9_/{}.,-]+/(exercise|solution)s?\.md`' "$MAP_FILE" | tr -d '`' | sort -u)
+
+if [[ $status -eq 0 ]]; then
+  echo "OK: all mapped exercise/solution paths exist under ref/comprehensive-rust/src"
+fi
+
+exit "$status"


### PR DESCRIPTION
Closes #6.

## Motivation
Issue #6: `/skill-stocktake` only checks a skill's `description:` triggers correctly and
doesn't duplicate a neighbor — it says nothing about whether a skill's *content* actually
steers someone toward the course's idiom when used to solve a real problem.

## Changes
- `docs/eval/README.md`:
  - A mapping of every upstream `exercise.md`/`solution.md` (or shared `solutions.md`)
    *coding* exercise to the skill(s) that should cover it, cross-referenced against each
    skill's `source:` frontmatter paths. Only 3 of the 11 skills have upstream chapters that
    ship a self-contained coding exercise + reference solution
    (`rust-ownership-and-lifetimes`, `rust-unsafe-fundamentals`, and the shared-`solutions.md`
    shape covering `rust-concurrency-sync`/`rust-async`); the rest derive from worked-example
    prose or discussion-only exercises with no code solution to compare against — documented
    explicitly as excluded, not left as a silent gap.
  - Methodology: **solve-blind, judge-with-solution** — a fresh subagent solves using only the
    skill + exercise skeleton (never `solution.md`); a separate pass compares the solver's
    technique against `solution.md`, specifically for the point the skill is meant to teach
    (not just "did tests pass" — a solution can pass via a less idiomatic route).
  - A PASS/PARTIAL/FAIL verdict scale and a per-exercise report format.
- `docs/eval/results/2026-09-01-pilot.md`: first run, 2 exercises against
  `rust-ownership-and-lifetimes` ("Wizard's Inventory" from `borrowing/`, "Protobuf Parsing"
  from `lifetimes/`). Both **PASS** — each solver's own report independently cited the exact
  skill section that matches the technique `solution.md` uses.
- `scripts/check-eval-map.sh`: local-only sanity check (not wired into CI —
  `ref/comprehensive-rust/` is gitignored and absent there) that the mapping's literal
  upstream paths still exist; run it after re-pinning the upstream commit.
- `docs/PLAN.md` Status section updated.

## Deferred (documented in docs/eval/README.md's Limitations section, not silently dropped)
- `unsafe-rust/exercise.md` ("Safe FFI Wrapper") — mapped but not run: needs a `libc`
  dev-dependency, and its content actually straddles `rust-unsafe-fundamentals`/`rust-ffi`
  rather than cleanly mapping to one skill (worth running with both loaded together).
- `concurrency/{sync,async}-exercises/*` — mapped but not run: the shared `solutions.md` file
  (multiple exercises' solutions in one page) needs splitting per-exercise before it fits the
  Assemble step cleanly.
- Long-term CI integration (noted in the issue itself) is intentionally not attempted here — an
  LLM-driven solve/judge step doesn't fit the deterministic jobs in
  `.github/workflows/ci.yml`.

## Attribution / duplication / line-budget impact
None — no `SKILL.md` content changed.

## Checks run (docs/WORKFLOW.md §7)
- `git diff --check` — clean
- `./scripts/check-skill-frontmatter.sh` — OK
- `./scripts/check-install-list-sync.sh` — OK
- `./scripts/check-links.sh` — OK
- `shellcheck --severity=warning install.sh scripts/*.sh` — clean (including the new
  `scripts/check-eval-map.sh`)
- `./scripts/check-eval-map.sh` — OK (all literal mapped paths exist under
  `ref/comprehensive-rust/src`)

## Not run
- `markdownlint-cli2` — same note as #19: the config from #18 isn't on `main` yet as of this
  branch's base. Checked manually against #18's config anyway (not part of this PR's diff): 0
  issues in the new `docs/eval/**` files.
- `/skill-stocktake` — not applicable, no skill content changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)