### PR TITLE
feat: add upstream drift detection script + scheduled workflow

### DIFF
--- a/.github/workflows/upstream-drift.yml
+++ b/.github/workflows/upstream-drift.yml
@@ -33,10 +33,14 @@ jobs:
           set -euo pipefail
           output="$(./scripts/check-upstream-drift.sh)"
           echo "$output"
+          # Random delimiter: $output embeds upstream file paths (google/comprehensive-rust,
+          # via scripts/check-upstream-drift.sh) — a fixed delimiter could in principle collide
+          # with a literal path segment and corrupt GITHUB_OUTPUT parsing.
+          delim="DRIFT_EOF_$(date +%s)_$RANDOM"
           {
-            echo "result<<DRIFT_EOF"
+            echo "result<<$delim"
             echo "$output"
-            echo "DRIFT_EOF"
+            echo "$delim"
           } >> "$GITHUB_OUTPUT"
           if echo "$output" | grep -q '^DRIFT:'; then
             echo "found=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/upstream-drift.yml
+++ b/.github/workflows/upstream-drift.yml
@@ -1,0 +1,83 @@
+# Scheduled check for upstream google/comprehensive-rust changes under any skill's declared
+# source paths since this repo's pinned commit (docs/PLAN.md's Upstream pin). See issue #7 and
+# scripts/check-upstream-drift.sh for the detection logic and why this uses the GitHub compare
+# API instead of cloning ref/comprehensive-rust (gitignored, not present in CI).
+#
+# On drift, opens (or comments on an existing open) an Issue labeled `upstream-drift` — this is
+# a notification mechanism, not an auto-fix: re-pinning and updating skill content stays a
+# manual Draft/Validate/Refine cycle per docs/WORKFLOW.md §4.
+
+name: Upstream drift check
+
+on:
+  schedule:
+    - cron: '0 9 * * 1' # Monday 09:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-drift:
+    name: Check upstream comprehensive-rust for drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run upstream drift check
+        id: drift
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          output="$(./scripts/check-upstream-drift.sh)"
+          echo "$output"
+          {
+            echo "result<<DRIFT_EOF"
+            echo "$output"
+            echo "DRIFT_EOF"
+          } >> "$GITHUB_OUTPUT"
+          if echo "$output" | grep -q '^DRIFT:'; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Ensure upstream-drift label exists
+        if: steps.drift.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh label create upstream-drift \
+            --color FBCA04 \
+            --description "Opened by .github/workflows/upstream-drift.yml" \
+            --force
+
+      - name: Open or update drift issue
+        if: steps.drift.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DRIFT_RESULT: ${{ steps.drift.outputs.result }}
+        run: |
+          set -euo pipefail
+          body="Automated check (\`.github/workflows/upstream-drift.yml\`, \`scripts/check-upstream-drift.sh\`) found upstream changes on [google/comprehensive-rust](https://github.com/google/comprehensive-rust) under one or more skills' declared source paths, since this repo's pinned commit (\`docs/PLAN.md\`'s Upstream pin).
+
+          \`\`\`
+          $DRIFT_RESULT
+          \`\`\`
+
+          Next steps: see \`docs/WORKFLOW.md\` §3.3 (re-cloning \`ref/comprehensive-rust\` at the new commit) and §4 (Draft/Validate/Refine) for updating the affected skill(s), then bump the \`source:\` pin per §8.
+
+          This issue is reopened or commented on again by the next scheduled run if the drift is still present — closing it without updating the affected skill(s) doesn't stop that."
+
+          existing="$(gh issue list --label upstream-drift --state open --json number --jq '.[0].number // empty')"
+          if [[ -n "$existing" ]]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create \
+              --title "Upstream comprehensive-rust drift detected" \
+              --body "$body" \
+              --label upstream-drift
+          fi

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -103,6 +103,16 @@ conversion mechanics (why `#[from]`/cross-error-type `?` works at all, which `ru
 own `thiserror` example relies on without explaining). Both are documented as small
 recommended edits for whoever maintains the `rust-patterns` repo, not applied here.
 
+**Upstream drift detection (2026-09-01, issue #7)**: added `scripts/check-upstream-drift.sh` —
+detects whether any file under a skill's declared `source:` paths changed on
+`google/comprehensive-rust`'s default branch since this repo's pinned commit, via the GitHub
+compare API (`gh api repos/google/comprehensive-rust/compare/<pin>...main`) rather than a
+local `ref/comprehensive-rust` clone (gitignored, absent in CI). Ran it locally: clean against
+the current pin (no drift), and verified the DRIFT-reporting path fires correctly against a
+deliberately older test commit. `.github/workflows/upstream-drift.yml` runs it weekly (Monday
+09:00 UTC) plus on `workflow_dispatch`, and opens/comments on an `upstream-drift`-labeled Issue
+when drift is found — notification only, not an auto-fix. See `docs/WORKFLOW.md` §11.
+
 Source map: [`FILE_MAP.md`](./FILE_MAP.md). Goal: turn Google's Comprehensive Rust course into
 a set of Claude Code **skills** (`SKILL.md` + `references/`), each scoped tightly enough to
 load fast and stay focused, together covering the course's teaching value — not a transcription

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -225,6 +225,7 @@ PASSとして報告しない。
 | --- | --- |
 | skillの追加・削除 | README（skill表・repository layout）、`docs/PLAN.md`（Skill catalog・Status） |
 | skillの`source:`pin更新 | 同じskillの他の記述箇所、必要なら`docs/PLAN.md`のUpstream pin |
+| skillの`source:`Paths変更 | `scripts/check-upstream-drift.sh`内のskill→pathマッピング（§11） |
 | skill間のdelineation変更 | `docs/PLAN.md`のdelineation table、影響するskillの相互参照 |
 | `install.sh`の挙動変更 | README（Install節）、`.github/workflows/ci.yml`のsmoke test手順 |
 | upstream courseの構造変化 | `docs/FILE_MAP.md` |
@@ -320,3 +321,22 @@ skill/docsの変更はmerge前に内容と配布経路の両面でレビュー�
 
 ファイル構成は変化するため、この文書に静的tree snapshotは置かない。確認時は
 `git ls-files`と`docs/PLAN.md`を正とする。
+
+## 11. 上流ドリフト検知（scheduled）
+
+`.github/workflows/upstream-drift.yml`（毎週月曜09:00 UTC + 手動`workflow_dispatch`）が
+`scripts/check-upstream-drift.sh`を実行し、各skillの`source:`frontmatterが指すupstream path
+配下に、`docs/PLAN.md`のUpstream pin以降の変更がないかを検査する。`ref/comprehensive-rust`の
+ローカルcloneには依存せず（gitignore対象でCIに存在しない、§3.3・§6参照）、GitHubの
+compare API（`gh api repos/google/comprehensive-rust/compare/<pin>...main`）で差分を検出する
+——56MBのfull cloneをCIで行うコストを避けるため。
+
+差分が見つかった場合、`upstream-drift`ラベル付きのIssueを新規作成（既存のopen issueがあれば
+コメント追記）する。これは通知のみで自動修正は行わない——影響を受けたskillの更新は通常どおり
+§4のDraft/Validate/Refineサイクルと§8のpin更新に従う。
+
+`scripts/check-upstream-drift.sh`内のskill→upstream path prefixマッピングは、各skillの
+`source:`frontmatterのPathsから手動で保守する（bash 3.2互換のため連想配列ではなくフラット
+リスト）。skillの`source:`Pathsを変更した場合はこのマッピングも同期させる（§8参照）。
+このworkflowは`.github/workflows/ci.yml`のPR gateとは独立しており、§9.2のCI job一覧には
+含まれない。

--- a/scripts/check-upstream-drift.sh
+++ b/scripts/check-upstream-drift.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Detect whether any file under a skill's declared upstream source paths has changed on
+# google/comprehensive-rust's default branch since this repo's pinned commit. Uses the GitHub
+# API's commit-compare endpoint (via `gh api`) rather than a local clone of
+# ref/comprehensive-rust — that directory is gitignored and not present in CI (see
+# docs/WORKFLOW.md §3.3, §6), and compare-by-API is far cheaper than cloning ~56MB just to run
+# `git diff` on a handful of paths.
+#
+# Requires: `gh` CLI, authenticated (already required for this repo's PR workflow; GitHub-hosted
+# Actions runners have `gh` preinstalled and GITHUB_TOKEN is enough to read a public repo).
+#
+# Output convention (grep-able by callers, e.g. .github/workflows/upstream-drift.yml):
+#   "DRIFT: <skill> — N changed path(s) under <prefix>: <file>, <file>, ..."  (one per hit)
+#   "OK: no upstream changes detected under any mapped skill's source paths"  (when clean)
+# Exit code reflects whether the check itself ran successfully — 0 even when drift is found,
+# non-zero only on a real failure (e.g. `gh api` error, missing pin). Callers that care whether
+# drift was found should grep stdout for "^DRIFT:", not rely on the exit code.
+#
+# Usage: ./scripts/check-upstream-drift.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$SCRIPT_DIR/.."
+PLAN_FILE="$REPO_DIR/docs/PLAN.md"
+UPSTREAM_REPO="google/comprehensive-rust"
+
+if [[ ! -f "$PLAN_FILE" ]]; then
+  echo "ERROR: $PLAN_FILE not found" >&2
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: gh CLI not found — required to query $UPSTREAM_REPO without a local clone" >&2
+  exit 1
+fi
+
+# Extract the pinned commit from "Upstream pin: `ref/comprehensive-rust` @ `<sha>` (<date>)."
+pin="$(grep -oE '^- \*\*Upstream pin\*\*: `ref/comprehensive-rust` @ `[0-9a-f]{7,40}`' "$PLAN_FILE" \
+  | grep -oE '[0-9a-f]{7,40}' | tail -1)"
+
+if [[ -z "$pin" ]]; then
+  echo "ERROR: could not find the Upstream pin commit in $PLAN_FILE" >&2
+  exit 1
+fi
+
+# skill -> upstream directory prefix(es), one "skill|prefix" pair per line. Kept as a flat list
+# (not an associative array) for bash 3.2 compatibility (docs/WORKFLOW.md §5). Derived from
+# each skill's `source:` frontmatter Paths — keep this in sync when a skill's Paths change
+# (docs/WORKFLOW.md §8 "skillのsource:pin更新" row).
+mapping="
+rust-ownership-and-lifetimes|src/borrowing
+rust-ownership-and-lifetimes|src/lifetimes
+rust-ownership-and-lifetimes|src/memory-management
+rust-ownership-and-lifetimes|src/smart-pointers
+rust-ownership-and-lifetimes|src/idiomatic/leveraging-the-type-system/borrow-checker-invariants
+rust-api-design|src/idiomatic/foundations-api-design
+rust-newtype-and-raii|src/idiomatic/leveraging-the-type-system/newtype-pattern
+rust-newtype-and-raii|src/idiomatic/leveraging-the-type-system/raii
+rust-typestate-and-tokens|src/idiomatic/leveraging-the-type-system/typestate-pattern
+rust-typestate-and-tokens|src/idiomatic/leveraging-the-type-system/token-types
+rust-polymorphism|src/idiomatic/polymorphism
+rust-polymorphism|src/idiomatic/leveraging-the-type-system/extension-traits
+rust-concurrency-sync|src/concurrency/threads
+rust-concurrency-sync|src/concurrency/channels
+rust-concurrency-sync|src/concurrency/send-sync
+rust-concurrency-sync|src/concurrency/shared-state
+rust-concurrency-sync|src/concurrency/sync-exercises
+rust-async|src/concurrency/async
+rust-async|src/concurrency/async-control-flow
+rust-async|src/concurrency/async-pitfalls
+rust-async|src/concurrency/async-exercises
+rust-unsafe-fundamentals|src/unsafe-rust
+rust-unsafe-soundness|src/unsafe-deep-dive/introduction
+rust-unsafe-soundness|src/unsafe-deep-dive/safety-preconditions
+rust-unsafe-soundness|src/unsafe-deep-dive/rules-of-the-game
+rust-unsafe-soundness|src/unsafe-deep-dive/initialization
+rust-unsafe-soundness|src/unsafe-deep-dive/memory-lifecycle
+rust-pinning|src/unsafe-deep-dive/pinning
+rust-ffi|src/unsafe-deep-dive/ffi
+"
+
+changed_files="$(gh api "repos/$UPSTREAM_REPO/compare/${pin}...main" --paginate \
+  --jq '.files[]?.filename' 2>&1)" \
+  || { echo "ERROR: gh api compare against $UPSTREAM_REPO failed: $changed_files" >&2; exit 1; }
+
+drift_found=0
+
+while IFS='|' read -r skill prefix; do
+  [[ -z "$skill" ]] && continue
+  matches="$(printf '%s\n' "$changed_files" | grep -E "^${prefix}(/|$)" || true)"
+  if [[ -n "$matches" ]]; then
+    drift_found=1
+    count="$(printf '%s\n' "$matches" | grep -c .)"
+    joined="$(printf '%s' "$matches" | tr '\n' ',' | sed 's/,$//' | sed 's/,/, /g')"
+    echo "DRIFT: $skill — $count changed path(s) under $prefix: $joined"
+  fi
+done <<< "$mapping"
+
+if [[ "$drift_found" -eq 0 ]]; then
+  echo "OK: no upstream changes detected under any mapped skill's source paths (pin: $pin)"
+fi
+
+exit 0

--- a/scripts/check-upstream-drift.sh
+++ b/scripts/check-upstream-drift.sh
@@ -78,6 +78,8 @@ rust-unsafe-soundness|src/unsafe-deep-dive/initialization
 rust-unsafe-soundness|src/unsafe-deep-dive/memory-lifecycle
 rust-pinning|src/unsafe-deep-dive/pinning
 rust-ffi|src/unsafe-deep-dive/ffi
+rust-ffi|src/android/interoperability/with-c
+rust-ffi|src/android/interoperability/cpp
 "
 
 changed_files="$(gh api "repos/$UPSTREAM_REPO/compare/${pin}...main" --paginate \


### PR DESCRIPTION
Closes #7.

## Motivation
Issue #7: `docs/PLAN.md` documents an "Updating from a newer course revision" procedure, but
nothing actually detects when upstream `google/comprehensive-rust` has moved under a skill's
declared source paths.

## Changes
- `scripts/check-upstream-drift.sh`: for each skill's `source:` path(s), checks whether any
  file under that path changed on upstream's default branch since this repo's pinned commit
  (`docs/PLAN.md`'s Upstream pin), using the GitHub compare API
  (`gh api repos/google/comprehensive-rust/compare/<pin>...main`) — not a local
  `ref/comprehensive-rust` clone, which is gitignored and absent in CI, and would mean cloning
  ~56MB just to diff a handful of paths.
  - The skill→path mapping is a flat `skill|prefix` list (bash 3.2 compatible — no associative
    arrays, per `docs/WORKFLOW.md` §5), derived directly from each skill's `source:`
    frontmatter Paths.
  - Output convention: `DRIFT: <skill> — ...` lines when found, `OK: ...` when clean; exit
    code reflects whether the check itself ran, not whether drift was found (callers grep for
    `^DRIFT:`).
- `.github/workflows/upstream-drift.yml`: runs the script weekly (Monday 09:00 UTC) plus
  `workflow_dispatch`. On drift, ensures an `upstream-drift` label exists and opens (or
  comments on an existing open) an Issue — notification only, no auto-fix. Separate from the
  PR-gating `.github/workflows/ci.yml`.
- `docs/WORKFLOW.md`: new §11 (appended at the end, so no existing section anchors — linked
  from CONTRIBUTING.md and elsewhere — shift), plus a §8 sync-table row for keeping the
  script's path mapping in sync with a skill's `source:` Paths.
- `docs/PLAN.md` Status section updated.

## Attribution / duplication / line-budget impact
None — no `SKILL.md` content changed.

## Checks run (docs/WORKFLOW.md §7)
- `git diff --check` — clean
- `./scripts/check-skill-frontmatter.sh` — OK
- `./scripts/check-install-list-sync.sh` — OK
- `./scripts/check-links.sh` — OK
- `shellcheck --severity=warning install.sh scripts/*.sh` — clean (including the new script)
- `npx --yes markdownlint-cli2 ...` — 0 issues
- `./scripts/check-upstream-drift.sh` — ran live against `google/comprehensive-rust`: `OK: no
  upstream changes detected` (pin `351fafa` is current). Also verified the DRIFT-reporting
  path fires correctly by testing against a deliberately older upstream commit (not part of
  this diff — a local-only test, reverted).
- `.github/workflows/upstream-drift.yml` validated with `actionlint` (clean) and a Python
  YAML parse (valid) — not part of the repo's documented gate, used as extra local
  verification for a new workflow file.

## Not run
- `/skill-stocktake` — not applicable, no skill content changed.
- The scheduled workflow itself hasn't fired in CI yet (first real run is the next Monday, or
  triggerable manually via `workflow_dispatch` after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)