### PR TITLE
docs: add dogfooding feedback log

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,3 +92,11 @@ Before merging:
 
 [`docs/WORKFLOW.md` §10](docs/WORKFLOW.md#10-レビューと完了条件) has the full completion
 checklist a change must satisfy before it's considered done.
+
+## Feedback from using a skill
+
+Used one of these skills in a real session and it helped (or didn't)? That's worth recording
+even without a PR — see [`docs/FEEDBACK.md`](docs/FEEDBACK.md) for the format. It's the
+lowest-friction way to surface a gap `/skill-stocktake` and `docs/eval/`'s exercise-based check
+can't catch on their own (both check the skill in the abstract, not what actually happened when
+someone used it).

--- a/docs/FEEDBACK.md
+++ b/docs/FEEDBACK.md
@@ -1,0 +1,38 @@
+# Dogfooding feedback log
+
+**Issue:** [#8](https://github.com/takurot/rust-skills-comprehensive/issues/8)
+
+A place to record whether a skill in this repo actually helped in a real session — not
+`/skill-stocktake`'s trigger/duplication check, and not `docs/eval/`'s exercise-based technique
+check, but "I loaded this mid-task and here's what happened." Both good and bad outcomes are
+worth recording; a skill that quietly didn't help is exactly the kind of thing
+`/skill-stocktake` and the eval suite can't catch on their own.
+
+## How to add an entry
+
+Append a new entry under [Entries](#entries) (newest first). Use this format:
+
+```markdown
+### <date> — <skill-name>
+
+**Situation:** What you were doing when the skill loaded (the task, not the whole session).
+
+**What worked:** What the skill got right — a specific pattern, pitfall, or diagnosis table
+row that was actually the thing you needed.
+
+**What didn't:** Gaps, wrong triggers, stale guidance, or content you had to override. Be
+specific enough that someone could act on it (a line number, a prompt that should/shouldn't
+have triggered it, an upstream page it contradicts).
+
+**Follow-up:** Link to an Issue/PR if one was filed as a result, or "none" if the feedback is
+recorded but not (yet) actioned.
+```
+
+Keep entries short — a few sentences per field is plenty. If a pattern of feedback across
+several entries suggests a real fix, file a GitHub Issue and reference it back from here (see
+[`CONTRIBUTING.md`](../CONTRIBUTING.md) for the issue-driven planning process) rather than
+editing the skill directly from a single feedback entry.
+
+## Entries
+
+_No entries yet — the earliest real feedback goes at the top of this section, newest first._


### PR DESCRIPTION
Closes #8.

## Motivation
Issue #8: there's no place to record "did this skill actually help in a real session" —
`/skill-stocktake` checks trigger/duplication in the abstract, and `docs/eval/` checks exercise
technique, but neither captures what happened when someone used a skill mid-task.

## Changes
- `docs/FEEDBACK.md`: an accumulation file with an entry format (situation, what worked, what
  didn't, follow-up) and instructions for adding an entry. Starts empty (no fabricated
  entries).
- `CONTRIBUTING.md`: new "Feedback from using a skill" section linking to it. README already
  links to CONTRIBUTING.md from its own Contributing section, satisfying the issue's
  "README または CONTRIBUTING からリンクされている" either/or.

## Attribution / duplication / line-budget impact
None — no `SKILL.md` touched.

## Checks run (docs/WORKFLOW.md §7)
- `git diff --check` — clean
- `./scripts/check-skill-frontmatter.sh` — OK
- `./scripts/check-install-list-sync.sh` — OK
- `./scripts/check-links.sh` — OK
- `shellcheck --severity=warning install.sh scripts/*.sh` — clean
- `npx --yes markdownlint-cli2 ...` — 0 issues
- Manually verified the `docs/FEEDBACK.md` link target from `CONTRIBUTING.md` resolves (that
  file isn't in `check-links.sh`'s scope — it only covers `skills/`, `README.md`, and
  `docs/*.md` at depth 1 — a pre-existing scope limit, not something this PR changes).

## Not run
- `/skill-stocktake` — not applicable, no skill content changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)