### PR TITLE
docs: add rust-patterns routing block + Day 1-2 gap check

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -39,10 +39,10 @@ and not shipped; consumers who need to re-derive a skill from source should clon
 themselves at the pinned commit. `LICENSE-CODE` (Apache-2.0) and `LICENSE-CONTENT` (CC-BY-4.0)
 vendor the upstream course's two license texts at the repo root.
 
-**Not yet done**: Phase 4 (routing block in `rust-patterns`, Day 1–2 gap-fill), Phase 5
-(platform skills — still gated on user confirmation). Exercise-based eval against the course's
-own exercises/solutions is now piloted for 2 exercises — see the entry below and
-`docs/eval/README.md` — with several mapped exercises still deferred to a follow-up.
+**Not yet done**: Phase 5 (platform skills — still gated on user confirmation). Exercise-based
+eval against the course's own exercises/solutions is now piloted for 2 exercises — see the
+entry below and `docs/eval/README.md` — with several mapped exercises still deferred to a
+follow-up. Phase 4 is done for what's in-scope for this repo — see the entry below.
 
 **CI hardening (2026-08-31, issues #1–#3)**: closed a real gap in `skill-frontmatter` —
 the script checked presence of frontmatter keys but never caught the actual `rust-pinning`
@@ -90,6 +90,18 @@ per-exercise before they fit the Assemble step). Not wired into `.github/workflo
 an LLM-driven solve/judge step doesn't fit the deterministic jobs there;
 `scripts/check-eval-map.sh` is a local-only sanity check that the mapping's literal upstream
 paths still exist, not a CI job.
+
+**Phase 4 (2026-09-01, issue #9)**: `rust-patterns` is not part of this repo — it lives in a
+separate repo (`everything-claude-code`) — so this repo's deliverable is the routing-block
+text and gap-check findings, not a direct edit to that skill; see
+`docs/rust-patterns-routing-block.md`. Checked every Day 1–2 topic in `docs/FILE_MAP.md`'s
+Core Language section against `rust-patterns/SKILL.md` (read in full) and the relevant
+upstream page: confirmed the `thiserror`/`anyhow` boundary is already covered correctly (the
+"verify before touching" item from this section's earlier note), and found 2 genuine gaps —
+`let else` (no example anywhere in `rust-patterns`) and the `?` operator's `From::from`
+conversion mechanics (why `#[from]`/cross-error-type `?` works at all, which `rust-patterns`'
+own `thiserror` example relies on without explaining). Both are documented as small
+recommended edits for whoever maintains the `rust-patterns` repo, not applied here.
 
 Source map: [`FILE_MAP.md`](./FILE_MAP.md). Goal: turn Google's Comprehensive Rust course into
 a set of Claude Code **skills** (`SKILL.md` + `references/`), each scoped tightly enough to
@@ -152,7 +164,9 @@ when that idiom **is** the task. If a new skill can't say materially more than t
 | calling C/C++ from Rust or vice versa | `rust-ffi` |
 
 Deliverable of Phase 4: add a short "see also" routing block to `rust-patterns` itself so it
-hands off rather than competing.
+hands off rather than competing. Done as of issue #9 — see
+[`docs/rust-patterns-routing-block.md`](rust-patterns-routing-block.md) (this repo produces
+the block; applying it lives in the `rust-patterns` repo, which this repo doesn't own).
 
 ## Module weights (course minutes)
 
@@ -257,10 +271,16 @@ useful outside Android/Chromium.
 
 ### Phase 4 — integration & gap-fill
 
+**Done (issue #9)** — see [`docs/rust-patterns-routing-block.md`](rust-patterns-routing-block.md)
+for the routing-block text and full gap-check table.
+
 - Add the "see also" routing block to `rust-patterns`.
 - Gap-check Day 1–2 content against `rust-patterns`; backfill only genuine gaps as small edits
   (candidates found in the map: `let-else`, try-conversions / `?` conversion mechanics,
   `thiserror` vs `anyhow` boundary — the last is already covered, verify before touching).
+  Confirmed: both `let-else` and try-conversions are genuine gaps, `thiserror`/`anyhow` is
+  already correctly covered. Since `rust-patterns` isn't part of this repo, backfilling is
+  recommended to whoever maintains it rather than applied here.
 - `rust-testing` verified adequate against the course's `testing/*` (unit, integration, doc tests,
   proptest, mockall, criterion, llvm-cov, CI all present). **No change planned.** Optional:
   clippy/lint guidance from `testing/lints.md` if not already in `rust-patterns`' tooling section.

--- a/docs/rust-patterns-routing-block.md
+++ b/docs/rust-patterns-routing-block.md
@@ -1,0 +1,79 @@
+# `rust-patterns` routing block + Day 1–2 gap check
+
+**Issue:** [#9](https://github.com/takurot/rust-skills-comprehensive/issues/9) — Phase 4
+(`docs/PLAN.md`'s "integration & gap-fill" phase, deliverable noted at PLAN.md's Delineation
+section and Phase 4 list).
+
+## Scope note
+
+`rust-patterns` is **not part of this repository** — it lives in a separate repo
+(`everything-claude-code`) and is installed at `~/.claude/skills/rust-patterns`. This repo's
+`docs/WORKFLOW.md` (branches, CI, PR review) governs `rust-skills-comprehensive` only, so this
+issue is closed here by producing the routing-block text and the gap-check findings as a
+ready-to-apply deliverable — actually pasting the block into `rust-patterns/SKILL.md` and
+committing there is a manual follow-up in that other repo, done by whoever maintains it, on its
+own review process. Do not silently take that step in this repo's PRs.
+
+## Routing block (paste into `rust-patterns/SKILL.md`)
+
+A short "see also" section, in `rust-patterns`' own house style (plain prose + a compact
+table, matching the format of that skill's existing sections). Suggested placement: right
+before its own "Quick Reference: Rust Idioms" table, or as a new final section before
+"Anti-Patterns to Avoid".
+
+```markdown
+## See Also — Deeper Dives
+
+This skill answers "what's the idiomatic default here?" in one screen. When the task **is**
+one of these specific problems, load the matching skill from
+[`rust-skills-comprehensive`](https://github.com/takurot/rust-skills-comprehensive) instead —
+they go deeper than a single screen can:
+
+| When... | Load |
+|---|---|
+| `rustc` reports a borrow/lifetime error, or choosing `&T` vs `Rc`/`RefCell`/`Cell` | `rust-ownership-and-lifetimes` |
+| Designing a library's public API — naming, doc comments, which traits to implement | `rust-api-design` |
+| Wrapping a value to enforce an invariant, or using `Drop` to guarantee cleanup | `rust-newtype-and-raii` |
+| Compile-time state machines (builders, protocol handshakes), permission/branded tokens | `rust-typestate-and-tokens` |
+| `dyn Trait` vs generics, sealing a trait, porting an inheritance-shaped design | `rust-polymorphism` |
+| `Send`/`Sync` compile errors, choosing a channel type, an `Arc<Mutex<T>>` deadlock | `rust-concurrency-sync` |
+| "Concurrent" async code that isn't, a hang at `.await`, a cancelled future losing state | `rust-async` |
+| Writing `unsafe` — raw pointers, mutable statics, `unsafe extern "C"` | `rust-unsafe-fundamentals` |
+| Auditing whether an `unsafe fn` is sound for *every* legal input | `rust-unsafe-soundness` |
+| `Pin<Ptr>`, `Unpin`, self-referential structs | `rust-pinning` |
+| Calling C/C++ from Rust or vice versa | `rust-ffi` |
+```
+
+This table is the same delineation this skill set already documents internally
+(`docs/PLAN.md`'s "Delineation vs. the existing `rust-patterns` / `rust-testing`" section) —
+kept in sync with it; if that table changes, update this block too (and re-apply it in the
+`rust-patterns` repo).
+
+## Day 1–2 gap check
+
+Checked every Day 1–2 topic in `docs/FILE_MAP.md`'s "Core Language" section against
+`rust-patterns/SKILL.md` (read in full, 500 lines) and, where relevant, the actual upstream
+page under `ref/comprehensive-rust/src/**`.
+
+| Topic | Verdict | Notes |
+|---|---|---|
+| Hello World, Types & Values, Control Flow, Tuples & Arrays, User-Defined Types (structs/enums/const/static) | Not a gap | Base Rust syntax — relies on the model's own Rust knowledge, consistent with `docs/PLAN.md`'s existing "adequately covered by `rust-patterns` plus base model" framing (PLAN.md's Phase-4 section). |
+| References (shared/exclusive/slices/dangling) | Not a gap | `rust-ownership-and-lifetimes` (this repo, Phase 1) covers this in depth for when it's the actual task; not `rust-patterns`' job to duplicate it. |
+| Pattern Matching — exhaustive `match`, enum modeling | Covered | `rust-patterns`' "Enums and Pattern Matching" section. |
+| **Pattern Matching — `let else`** | **Gap** | `rust-patterns` has no `let else` example anywhere. Upstream (`pattern-matching/let-control-flow/let-else.md`) frames it as *the* idiomatic form for "match a pattern or return/break/panic" — currently absent even though the adjacent `if let`/nested-match style is implicitly discouraged elsewhere in the skill (its "Option Combinators Over Nested Matching" section). |
+| Methods & Traits, Generics (trait bounds, `impl Trait`, `dyn Trait` vs generics) | Covered | "Traits and Generics" section. |
+| Closures (`Fn`/`FnMut`/`FnOnce`, capturing) | Not a gap | Common enough base-model knowledge; not called out in `docs/PLAN.md`'s own Phase-4 candidate list either. Noted here for completeness rather than left silently unchecked. |
+| Standard Library Types (`Option`/`Result`/`String`/`Vec`/`HashMap`) | Covered | `Option` combinators, `Result`/`?`, `collect()` into various types. |
+| Standard Library Traits (`From`/`Into`, comparisons, `Default`) | Partially covered | `From` appears only inside the `thiserror` example (`#[from] std::io::Error`); no explicit `Into`/`Default` guidance. Not flagged as a standalone gap — see the `?`/`From` finding below, which is the concrete case where this actually bites. |
+| Iterators | Covered | "Prefer Iterator Chains Over Manual Loops", `collect()` with type annotation. |
+| Modules | Covered | "Module System and Crate Structure" section. |
+| Testing | Out of scope for this check | Already verified adequate against the course by a prior pass (`docs/PLAN.md`'s Phase-4 note: "`rust-testing` verified adequate... **No change planned.**"), covered by the separate `rust-testing` skill, not `rust-patterns`. |
+| Error Handling — `Result`/`?`, panics discipline | Covered | "Use `Result` and `?` — Never `unwrap()` in Production". |
+| Error Handling — `thiserror` vs `anyhow` boundary | **Confirmed already covered** (per `docs/PLAN.md`'s own note to "verify before touching") | `rust-patterns`' "Library Errors with `thiserror`, Application Errors with `anyhow`" section matches the upstream `error-handling/{thiserror,anyhow}.md` split correctly (library → typed errors via `thiserror`; application → `anyhow::Result`/`bail!`). No action needed. |
+| **Error Handling — try-conversions (`?`'s `From::from` mechanics)** | **Gap** | `rust-patterns` shows `?` propagating errors but never explains *why* it works when the inner and outer error types differ — upstream's `error-handling/try-conversions.md` is explicit that `expr?` desugars to `match expr { Ok(v) => v, Err(e) => return Err(From::from(e)) }`, so a `From<InnerErr> for OuterErr` impl (as `rust-patterns`' own `thiserror` example actually uses, via `#[from]`) is *why* `?` can cross error-type boundaries at all. Without this, the `#[from]` attribute reads as unexplained magic. |
+| Unsafe Rust (intro-level) | Covered, correctly delineated | `rust-patterns`' "Unsafe Code" section (acceptable/not-acceptable, `# Safety` comments) matches the upstream intro page's level; `rust-unsafe-fundamentals`/`rust-unsafe-soundness` (this repo) go deeper for when that's the actual task — no gap, no duplication. |
+
+**Summary: 2 genuine gaps** — `let else`, and the `?`/`From` conversion mechanics behind
+`thiserror`'s `#[from]`. Both are small (the upstream pages are 76 and 106 lines respectively,
+mostly one code example each) and are recommended as small edits to `rust-patterns` itself
+(not this repo) — see the Scope note above for why this repo doesn't apply them directly.


### PR DESCRIPTION
Closes #9.

## Motivation
Issue #9: `docs/PLAN.md`'s Phase 4 (integration & gap-fill) was unstarted — add a "see also"
routing block to `rust-patterns`, and check Day 1-2 content for gaps against it.

## Scope note
`rust-patterns` is **not part of this repository** — it lives in a separate repo
(`everything-claude-code`) and is installed at `~/.claude/skills/rust-patterns`. Per discussion
before implementing, this repo's deliverable is the routing-block text and gap-check findings
as a ready-to-apply artifact; actually pasting it into `rust-patterns/SKILL.md` and committing
there is a manual follow-up in that repo, on its own review process — not done here.

## Changes
- `docs/rust-patterns-routing-block.md`:
  - The routing-block Markdown itself (a "See Also — Deeper Dives" section + table), ready to
    paste into `rust-patterns/SKILL.md`, kept consistent with this repo's own delineation
    table (`docs/PLAN.md`).
  - A full Day 1-2 gap-check table: every topic in `docs/FILE_MAP.md`'s Core Language section,
    checked against `rust-patterns/SKILL.md` (read in full, 500 lines) and the relevant
    upstream page. Confirmed `thiserror`/`anyhow` boundary is already covered correctly
    (`docs/PLAN.md`'s "verify before touching" item). Found 2 genuine gaps: `let else` (no
    example anywhere in `rust-patterns`) and the `?` operator's `From::from` conversion
    mechanics (which `rust-patterns`' own `thiserror` `#[from]` example relies on without
    explaining).
- `docs/PLAN.md`: Status section, Phase 4 plan entries, and the Delineation section's
  "Deliverable of Phase 4" line all updated to mark this done with the cross-repo caveat noted.

## Attribution / duplication / line-budget impact
None — no `SKILL.md` in this repo changed. The gap-check findings recommend edits to
`rust-patterns` (a skill outside this repo), not applied here.

## Checks run (docs/WORKFLOW.md §7)
- `git diff --check` — clean
- `./scripts/check-skill-frontmatter.sh` — OK
- `./scripts/check-install-list-sync.sh` — OK
- `./scripts/check-links.sh` — OK
- `shellcheck --severity=warning install.sh scripts/*.sh` — clean
- `npx --yes markdownlint-cli2 ...` — 0 issues

## Not run
- `/skill-stocktake` — not applicable, no skill content in this repo changed.
- No changes were made to `rust-patterns` itself (out of this repo's scope — see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)