### PR TITLE
fix: rust-unsafe-soundness description truncated by YAML comment

### DIFF
--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -129,7 +129,7 @@ commitと異なる版を使う場合は、更新後にpinを書き換える（§
 
 | 確認項目 | 方法 |
 | --- | --- |
-| Frontmatter形式 | `name`・`description`・`source`が揃っている。`description:`は引用符なしのYAML plain scalarなので、値のどこであれ`: `（コロン+空白）を含めると値がそこで切れる（過去に発生したparser不具合、`docs/PLAN.md`参照）。`./scripts/check-skill-frontmatter.sh`（CIの`skill-frontmatter` jobと同じ）で機械的に確認できる |
+| Frontmatter形式 | `name`・`description`・`source`が揃っている。`description:`は引用符なしのYAML plain scalarなので、値のどこであれ`: `（コロン+空白）を含めると値がそこで切れる（過去に発生したparser不具合、`docs/PLAN.md`参照）。同様に` #`（空白+ハッシュ）もYAMLコメントの開始とみなされ、それ以降が切れる（`rust-unsafe-soundness`の"# Safety doc section"で再発、issue #24）。`./scripts/check-skill-frontmatter.sh`（CIの`skill-frontmatter` jobと同じ）で両方とも機械的に確認できる |
 | Line budget | 同スクリプトが500行のhard budgetを超えていないかCIで検査する。ソフトな目安（既存skillのレンジ137–233行）から大きく外れる場合は`references/`分割を検討する——こちらはCIでは強制しない |
 | Trigger起動性 | そのskillが起動すべき/すべきでない代表的なpromptを数個想定し、`description`の語彙で自己判別できるか確認する（近縁skillとの誤起動がないか） |
 | Attribution | `source:`のCC-BY-4.0/Apache-2.0表記とpinned commitが正しい |

--- a/scripts/check-skill-frontmatter.sh
+++ b/scripts/check-skill-frontmatter.sh
@@ -50,6 +50,20 @@ for skill_md in "$SKILLS_DIR"/*/SKILL.md; do
     status=1
   fi
 
+  # Same hazard, different character: a space followed by '#' starts a YAML
+  # comment in an unquoted plain scalar, silently truncating everything
+  # after it — this bit rust-unsafe-soundness's description ("...writing a
+  # # Safety doc section...") in exactly the same way as the ': ' case
+  # above (issue #24). Skip this check if the value is already quoted
+  # (starts with a literal '"' or "'"), where '#' has no special meaning.
+  case "$fm_desc" in
+    '"'*|"'"*) ;;
+    *' #'*)
+      echo "FAIL: $skill_md — description contains ' #' (space+hash), which starts a YAML comment in an unquoted value and truncates everything after it — rewrite to avoid it (docs/WORKFLOW.md §4.2)"
+      status=1
+      ;;
+  esac
+
   lines="$(wc -l < "$skill_md" | tr -d ' ')"
   if (( lines > MAX_LINES )); then
     echo "FAIL: $skill_md — $lines lines exceeds the ${MAX_LINES}-line budget (docs/WORKFLOW.md §1)"

--- a/skills/rust-unsafe-soundness/SKILL.md
+++ b/skills/rust-unsafe-soundness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-unsafe-soundness
-description: Reason rigorously about whether unsafe Rust is sound — derive and document safety preconditions, tell encapsulated vs exposed unsafe apart, spot "crying wolf" unsafe markers, and use MaybeUninit for uninitialized/partially-initialized memory. Use when auditing an unsafe function for soundness, writing a # Safety doc section, or deciding whether a safe wrapper around unsafe code is actually sound for every possible caller input.
+description: Reason rigorously about whether unsafe Rust is sound — derive and document safety preconditions, tell encapsulated vs exposed unsafe apart, spot "crying wolf" unsafe markers, and use MaybeUninit for uninitialized/partially-initialized memory. Use when auditing an unsafe function for soundness, documenting an unsafe function's safety preconditions, or deciding whether a safe wrapper around unsafe code is actually sound for every possible caller input.
 source: |
   Adapted from Comprehensive Rust (https://google.github.io/comprehensive-rust/),
   © Google LLC, CC-BY-4.0. Code samples Apache-2.0. Source pin: 351fafa (2026-08-05).


### PR DESCRIPTION
Closes #24

## 変更内容
- `skills/rust-unsafe-soundness/SKILL.md`: description内の ` # Safety doc section` を、意味を保ったまま ` #`（YAMLコメント開始のトリガー）を含まない表現に書き換え
- `scripts/check-skill-frontmatter.sh`: 既存の`: `（コロン+空白）チェックに加えて、` #`（空白+ハッシュ）を検出するチェックを追加（クォート済みdescriptionは対象外）
- `docs/WORKFLOW.md` §4.2: 上記の教訓を既存の`: `の注記と並べて追記

## 根拠
PyYAML (`yaml.safe_load`) で実際に検証し、修正前は"...writing a"で切断されることを確認。修正後は全文がパースされることを確認済み（本文参照）。

## 実行した確認（docs/WORKFLOW.md §7）
- [x] `git diff --check`
- [x] `./scripts/check-skill-frontmatter.sh` — pass。さらに回帰テストとして、元の壊れた文言に一時的に戻して新チェックが検出することを確認し、戻して再度pass することも確認
- [x] `./scripts/check-install-list-sync.sh` — pass
- [x] `./scripts/check-links.sh` — pass
- [x] `shellcheck --severity=warning install.sh scripts/*.sh` — pass
- [x] `markdownlint-cli2`（CIと同glob） — 0 issues

## 影響範囲
- attribution・重複回避・line budgetへの影響なし（frontmatterのdescriptionの言い回し変更のみ、`source:`は変更なし）
- 他10 skillへの影響なし（` #`を含むdescriptionは元々この1件のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfU8AzaQQLauJSXh7dKZPs