### PR TITLE
fix: install.sh exits non-zero on unknown skill name / missing --dest arg

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -51,7 +51,12 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --dest)
-            if [[ $# -lt 2 ]]; then
+            # Reject a missing argument *and* the next token being another
+            # flag (e.g. `--dest --force`) — both used to fall through to
+            # PROJECT_DIR="$2" and fail later with a raw, confusing error
+            # (an unbound-variable crash, or `mkdir: illegal option --`)
+            # instead of this script's own usage message (issue #25 review).
+            if [[ $# -lt 2 || "$2" == -* ]]; then
                 echo "error: --dest requires a path argument" >&2
                 usage
                 exit 1

--- a/install.sh
+++ b/install.sh
@@ -51,6 +51,11 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --dest)
+            if [[ $# -lt 2 ]]; then
+                echo "error: --dest requires a path argument" >&2
+                usage
+                exit 1
+            fi
             SCOPE="custom"
             PROJECT_DIR="$2"
             shift 2
@@ -111,10 +116,12 @@ echo
 
 installed=0
 skipped=0
+not_found=0
 for name in "${SELECTED[@]}"; do
     src="$SKILLS_SRC/$name"
     if [[ ! -d "$src" ]]; then
         echo "  ✗ $name — no such skill in $SKILLS_SRC (see --list)" >&2
+        not_found=$((not_found + 1))
         continue
     fi
 
@@ -142,4 +149,9 @@ echo "Done: $installed installed, $skipped skipped."
 if [[ "$SCOPE" == "project" ]]; then
     echo "Installed to the project you ran this from: $DEST"
     echo "Re-run from a different project directory, or with --global, as needed."
+fi
+
+if [[ $not_found -gt 0 ]]; then
+    echo "error: $not_found skill name(s) did not match any directory under $SKILLS_SRC (see --list)" >&2
+    exit 1
 fi


### PR DESCRIPTION
Closes #25

## 変更内容
1. skill名が1件でも解決できなかった場合、実行結果の要約表示後に非ゼロ終了コード(1)を返すようにした（有効なskillは引き続きインストールされる——このPRは最終的な終了コードのみに影響）
2. `--dest`に引数が渡されなかった場合、`$2: unbound variable`という生のbashエラーではなく、独自のエラーメッセージ+usage+exit 1になるようにした

## 実行した確認（docs/WORKFLOW.md §5、手動）
- [x] `--list` — 一覧が正しく出る
- [x] copy install（単一skill） — exit 0
- [x] symlink install — exit 0
- [x] 再実行（`--force`なし） — skipされる、exit 0
- [x] `--force`での上書き — exit 0
- [x] **NEW**: 不正skill名 — exit 1（修正前はexit 0だった）
- [x] **NEW**: 有効+不正skill名の混在 — 有効な方は引き続きインストールされつつ、exit 1になる
- [x] **NEW**: `--dest`引数欠落 — usageを表示してexit 1（修正前は`$2: unbound variable`で終了）

## 実行した確認（docs/WORKFLOW.md §7）
- [x] `git diff --check`
- [x] `shellcheck --severity=warning install.sh scripts/*.sh` — pass
- [x] `./scripts/check-install-list-sync.sh` — pass（install.shの他の出力に影響なし）
- [x] `./scripts/check-skill-frontmatter.sh` / `./scripts/check-links.sh` / markdownlint — 変更なしのため参考実行、pass

## 影響範囲
- 正常系の挙動（インストールされるファイル・出力メッセージ）は一切変更していない。異常系の終了コードとエラーメッセージのみの変更
- `.github/workflows/ci.yml`の`install-smoke-test` jobは正常系のみを対象にしており、今回追加した異常系はこのPRでは自動化していない（follow-upの余地として認識——このPRのスコープは#25の指摘への対応のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfU8AzaQQLauJSXh7dKZPs