### PR TITLE
fix: install.sh --list description truncates on ': ' in description text

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -36,7 +36,11 @@ list_skills() {
     echo "Available skills:"
     for d in "$SKILLS_SRC"/*/; do
         name="$(basename "$d")"
-        desc="$(awk -F': ' '/^description:/{ $1=""; print substr($0,2); exit }' "$d/SKILL.md")"
+        # Strip only the leading "description: " prefix — do NOT split on
+        # ': ' generally (awk -F': ' used to do this, and truncated any
+        # description containing ': ' elsewhere in its text, e.g. a quoted
+        # error message like `"error: something"` — issue #26).
+        desc="$(sed -n 's/^description: *//p' "$d/SKILL.md" | head -1)"
         printf '  %-28s %s\n' "$name" "$desc"
     done
 }


### PR DESCRIPTION
Closes #26

## 変更内容
`list_skills()`のdescription抽出を`awk -F': '`（コロン+空白で分割）から、`check-skill-frontmatter.sh`と同じ`sed -n 's/^description: *//p'`（先頭の`description: `だけを剥がす）方式に変更。

## 根拠（再現テスト）
合成skillフィクスチャで確認:
- description: `Use when you see "error: something", or other pattern.`
- 旧実装（awk）: `Use when you see "error something", or other pattern.` （`: `が消える）
- 新実装（sed）: `Use when you see "error: something", or other pattern.` （全文保持）

既存11 skillのdescriptionには`: `を含むものが無いため今まで表面化していなかった。

## 実行した確認
- [x] 既存11 skillの`./install.sh --list`出力が変更前後でbyte-for-byte一致することを確認（`diff`で差分なし）
- [x] 合成フィクスチャで新旧の抽出結果を比較し、修正が機能することを確認
- [x] `shellcheck --severity=warning install.sh scripts/*.sh` — pass
- [x] `./scripts/check-install-list-sync.sh` — pass
- [x] `git diff --check`
- [x] copy installの正常系（`--dest`単一skill）— exit 0、影響なし確認

## 影響範囲
- `list_skills()`の内部実装のみの変更。出力される11 skillの表示内容は不変（上記diffで確認済み）
- 他のフラグ処理・インストールロジックには触れていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfU8AzaQQLauJSXh7dKZPs