### PR TITLE
docs: clarify license scope for original repo files

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ rust-skills-comprehensive/
 ├── CLAUDE.md                # repo-specific behavioral guidelines for Claude Code
 ├── CONTRIBUTING.md          # skill-authoring process, pre-PR checks, commit/PR conventions
 ├── .markdownlint-cli2.jsonc # markdownlint config used by CI and local checks
-├── LICENSE-CODE             # Apache-2.0 — covers the Rust code samples inside each skill
+├── LICENSE-CODE             # Apache-2.0 — covers code samples in skills, and this repo's own
+│                             #  scripts/docs (see Attribution & license below)
 ├── LICENSE-CONTENT          # CC-BY-4.0 — covers the prose, adapted from the course
 └── ref/                     # (gitignored) local clone of the upstream course, used only
                               #  while authoring/updating skills — not part of this distribution
@@ -151,8 +152,8 @@ This repository's contents fall into two categories with different licenses:
 - **Everything else original to this repository** — `install.sh`, `scripts/*.sh`,
   `.github/workflows/*.yml`, and the docs in `docs/*.md` (`PLAN.md`, `WORKFLOW.md`,
   `FILE_MAP.md`, `FEEDBACK.md`, `eval/`, etc.), plus `CONTRIBUTING.md` and `CLAUDE.md` — is not
-  derived from the upstream course and is licensed [Apache-2.0](LICENSE-CODE), the same license
-  file used above.
+  derived from the upstream course and is licensed [Apache-2.0](LICENSE-CODE) — the same
+  `LICENSE-CODE` file, since its Apache-2.0 text isn't scoped to any single work.
 
 If you edit or extend a skill here in a way that still derives from the course text, keep the
 attribution note in that skill's frontmatter and this README's license section accurate.

--- a/README.md
+++ b/README.md
@@ -140,11 +140,19 @@ platform-specific tracks), and what's still open.
 
 ## Attribution & license
 
-The skills' prose is adapted from [Comprehensive Rust](https://google.github.io/comprehensive-rust/)
-by Google LLC, licensed [CC-BY-4.0](LICENSE-CONTENT) — see that file for the full license.
-Rust code samples in the original course (and reproduced or adapted in these skills) are
-licensed [Apache-2.0](LICENSE-CODE). Each `SKILL.md`'s frontmatter names the exact upstream
-paths it draws from and the pinned commit.
+This repository's contents fall into two categories with different licenses:
+
+- **Skill content derived from Comprehensive Rust** (`skills/**/SKILL.md`): the prose is
+  adapted from [Comprehensive Rust](https://google.github.io/comprehensive-rust/) by Google
+  LLC, licensed [CC-BY-4.0](LICENSE-CONTENT) — see that file for the full license. Rust code
+  samples in the original course (and reproduced or adapted in these skills) are licensed
+  [Apache-2.0](LICENSE-CODE). Each `SKILL.md`'s frontmatter names the exact upstream paths it
+  draws from and the pinned commit.
+- **Everything else original to this repository** — `install.sh`, `scripts/*.sh`,
+  `.github/workflows/*.yml`, and the docs in `docs/*.md` (`PLAN.md`, `WORKFLOW.md`,
+  `FILE_MAP.md`, `FEEDBACK.md`, `eval/`, etc.), plus `CONTRIBUTING.md` and `CLAUDE.md` — is not
+  derived from the upstream course and is licensed [Apache-2.0](LICENSE-CODE), the same license
+  file used above.
 
 If you edit or extend a skill here in a way that still derives from the course text, keep the
 attribution note in that skill's frontmatter and this README's license section accurate.


### PR DESCRIPTION
## Summary
Fixes #29.

The README's Attribution & license section previously only described licensing for skill content (`skills/**/SKILL.md`) derived from upstream Comprehensive Rust. It said nothing about this repo's own original files (`install.sh`, `scripts/*.sh`, `.github/workflows/*.yml`, `docs/*.md`, `CONTRIBUTING.md`, `CLAUDE.md`), leaving them with no stated license.

This PR restructures the section into two explicit categories:
1. Skill content adapted from upstream — CC-BY-4.0 (prose) / Apache-2.0 (code samples), unchanged from before.
2. Everything else original to this repo — explicitly licensed Apache-2.0, reusing the existing `LICENSE-CODE` file (a generic Apache-2.0 grant, not scoped to just Rust samples by the license text itself).

No new LICENSE file was added since `LICENSE-CODE` already carries the full, unrestricted Apache-2.0 text — the restriction was only in the README's prose framing.

## Checks run (docs/WORKFLOW.md §7)
- `git diff --check` — clean
- `./scripts/check-links.sh` — OK
- `npx markdownlint-cli2` — 0 issues

Not applicable: frontmatter/install-list-sync/shellcheck (no skill or install.sh changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)