### PR TITLE
fix: detect truncated GitHub compare API results in upstream drift check

### DIFF
--- a/.github/workflows/upstream-drift.yml
+++ b/.github/workflows/upstream-drift.yml
@@ -30,8 +30,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
+          # Don't let `set -e` abort here: scripts/check-upstream-drift.sh now exits non-zero
+          # both on a real failure (gh api error, missing pin) and on a suspected-truncated
+          # compare (see the script's header comment) — the latter still needs its output
+          # captured and turned into an issue below, not just a red CI run that's easy to miss
+          # on a weekly schedule.
           output="$(./scripts/check-upstream-drift.sh)"
+          exit_code=$?
+          set -e
           echo "$output"
           # Random delimiter: $output embeds upstream file paths (google/comprehensive-rust,
           # via scripts/check-upstream-drift.sh) — a fixed delimiter could in principle collide
@@ -47,9 +54,20 @@ jobs:
           else
             echo "found=false" >> "$GITHUB_OUTPUT"
           fi
+          if echo "$output" | grep -q '^WARNING: compare result may be truncated'; then
+            echo "truncated=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "truncated=false" >> "$GITHUB_OUTPUT"
+          fi
+          # A non-zero exit that isn't explained by truncation is a real failure (gh api error,
+          # missing pin, etc.) — fail the job so it's visible, same as before this change.
+          if [[ "$exit_code" -ne 0 ]] && [[ "$(echo "$output" | grep -c '^WARNING: compare result may be truncated')" -eq 0 ]]; then
+            echo "check-upstream-drift.sh failed (exit $exit_code) for a reason other than truncation" >&2
+            exit "$exit_code"
+          fi
 
       - name: Ensure upstream-drift label exists
-        if: steps.drift.outputs.found == 'true'
+        if: steps.drift.outputs.found == 'true' || steps.drift.outputs.truncated == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -60,28 +78,37 @@ jobs:
             --force
 
       - name: Open or update drift issue
-        if: steps.drift.outputs.found == 'true'
+        if: steps.drift.outputs.found == 'true' || steps.drift.outputs.truncated == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           DRIFT_RESULT: ${{ steps.drift.outputs.result }}
+          TRUNCATED: ${{ steps.drift.outputs.truncated }}
         run: |
           set -euo pipefail
-          body="Automated check (\`.github/workflows/upstream-drift.yml\`, \`scripts/check-upstream-drift.sh\`) found upstream changes on [google/comprehensive-rust](https://github.com/google/comprehensive-rust) under one or more skills' declared source paths, since this repo's pinned commit (\`docs/PLAN.md\`'s Upstream pin).
+          if [[ "$TRUNCATED" == "true" ]]; then
+            title="Upstream comprehensive-rust drift check: automated detection incomplete (truncated compare)"
+            intro="Automated check (\`.github/workflows/upstream-drift.yml\`, \`scripts/check-upstream-drift.sh\`) could **not fully compare** this repo's pinned commit against [google/comprehensive-rust](https://github.com/google/comprehensive-rust)'s default branch — the GitHub compare API's \`files\` list appears truncated (it caps around 300 entries with no further pagination). Any \`DRIFT:\` lines below are still real, but the absence of a \`DRIFT:\` line for a given skill does **not** mean it's clean — paths beyond the cap were never checked."
+          else
+            title="Upstream comprehensive-rust drift detected"
+            intro="Automated check (\`.github/workflows/upstream-drift.yml\`, \`scripts/check-upstream-drift.sh\`) found upstream changes on [google/comprehensive-rust](https://github.com/google/comprehensive-rust) under one or more skills' declared source paths, since this repo's pinned commit (\`docs/PLAN.md\`'s Upstream pin)."
+          fi
+
+          body="$intro
 
           \`\`\`
           $DRIFT_RESULT
           \`\`\`
 
-          Next steps: see \`docs/WORKFLOW.md\` §3.3 (re-cloning \`ref/comprehensive-rust\` at the new commit) and §4 (Draft/Validate/Refine) for updating the affected skill(s), then bump the \`source:\` pin per §8.
+          Next steps: see \`docs/WORKFLOW.md\` §3.3 (re-cloning \`ref/comprehensive-rust\` at the new commit) and §4 (Draft/Validate/Refine) for updating the affected skill(s), then bump the \`source:\` pin per §8. A truncated compare is best resolved by bumping the pin closer to upstream's current \`main\` (shrinking the compare range) and re-running this check, or by reviewing manually against a local clone.
 
-          This issue is reopened or commented on again by the next scheduled run if the drift is still present — closing it without updating the affected skill(s) doesn't stop that."
+          This issue is reopened or commented on again by the next scheduled run if the drift or truncation is still present — closing it without updating the affected skill(s) (or the pin) doesn't stop that."
 
           existing="$(gh issue list --label upstream-drift --state open --json number --jq '.[0].number // empty')"
           if [[ -n "$existing" ]]; then
             gh issue comment "$existing" --body "$body"
           else
             gh issue create \
-              --title "Upstream comprehensive-rust drift detected" \
+              --title "$title" \
               --body "$body" \
               --label upstream-drift
           fi

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -113,6 +113,27 @@ deliberately older test commit. `.github/workflows/upstream-drift.yml` runs it w
 09:00 UTC) plus on `workflow_dispatch`, and opens/comments on an `upstream-drift`-labeled Issue
 when drift is found — notification only, not an auto-fix. See `docs/WORKFLOW.md` §11.
 
+**Upstream drift detection: truncation handling (2026-09-01, issue #30)**: the compare API's
+`files` array is capped (observed cap: 300 entries) with no Link-header pagination available to
+recover files past it, so a pin old enough to accumulate >300 changed files upstream could have
+silently produced a false `OK: no upstream changes detected`. `check-upstream-drift.sh` now
+reads `.truncated` and `.files | length` from the compare response and, on a suspected
+truncation (either signal), emits a `WARNING: compare result may be truncated ...` line and
+exits non-zero instead of `OK:`; `upstream-drift.yml` treats that the same as `DRIFT:` for
+opening/commenting on the `upstream-drift`-labeled Issue, but with a title/body that says
+detection was incomplete rather than claiming clean drift. Verified manually (no >300-file test
+fixture available against the live pin): (1) ran the real `gh api` call against the current pin
+— clean, non-truncated, `OK:` as before; (2) confirmed the `--jq` filter's correctness against
+a locally saved compare response with `jq` directly (an earlier version of the filter had a jq
+operator-precedence bug — `[...] | join(" "), (.files[]?.filename)` binds the trailing
+`(.files[]?.filename)` inside the piped RHS rather than back at the root — fixed by wrapping the
+first branch in its own parens before the comma); (3) exercised the truncation-detected code
+path by substituting a mocked `compare_output` (`truncated=true`, `files_count=300`, one fake
+changed path) for the `gh api` call in a scratch copy of the script, confirming both the
+`DRIFT:` line for the fake path and the `WARNING:` line print together with a non-zero exit;
+(4) validated `.github/workflows/upstream-drift.yml`'s YAML with
+`python3 -c "import yaml; yaml.safe_load(...)"` after the edit.
+
 Source map: [`FILE_MAP.md`](./FILE_MAP.md). Goal: turn Google's Comprehensive Rust course into
 a set of Claude Code **skills** (`SKILL.md` + `references/`), each scoped tightly enough to
 load fast and stay focused, together covering the course's teaching value — not a transcription

--- a/scripts/check-upstream-drift.sh
+++ b/scripts/check-upstream-drift.sh
@@ -12,9 +12,13 @@
 # Output convention (grep-able by callers, e.g. .github/workflows/upstream-drift.yml):
 #   "DRIFT: <skill> — N changed path(s) under <prefix>: <file>, <file>, ..."  (one per hit)
 #   "OK: no upstream changes detected under any mapped skill's source paths"  (when clean)
+#   "WARNING: compare result may be truncated ..."  (files list looks incomplete — see below)
 # Exit code reflects whether the check itself ran successfully — 0 even when drift is found,
-# non-zero only on a real failure (e.g. `gh api` error, missing pin). Callers that care whether
-# drift was found should grep stdout for "^DRIFT:", not rely on the exit code.
+# non-zero only on a real failure (e.g. `gh api` error, missing pin) *or* a suspected-truncated
+# compare (see below) — "OK" would be a false negative there. Callers that care whether drift
+# was found should grep stdout for "^DRIFT:", not rely on the exit code; callers that need to
+# tell truncation apart from a transport error should grep for "^WARNING: compare result may be
+# truncated".
 #
 # Usage: ./scripts/check-upstream-drift.sh
 
@@ -82,9 +86,30 @@ rust-ffi|src/android/interoperability/with-c
 rust-ffi|src/android/interoperability/cpp
 "
 
-changed_files="$(gh api "repos/$UPSTREAM_REPO/compare/${pin}...main" --paginate \
-  --jq '.files[]?.filename' 2>&1)" \
-  || { echo "ERROR: gh api compare against $UPSTREAM_REPO failed: $changed_files" >&2; exit 1; }
+# Fetch truncation signal (`.truncated`, if the API ever sets it) and the returned file count
+# on the first line, then the changed filenames — one `gh api` call, split with `tail`/`head`
+# so we don't need a second round trip. No `--paginate`: this endpoint returns a single object,
+# not a list, and `--paginate` mishandles the multi-line `--jq` output above (it expects the
+# filtered result to be a JSON array to concatenate across pages). Link-header pagination
+# wouldn't recover files past the `files` array cap anyway — see the truncation check below.
+compare_output="$(gh api "repos/$UPSTREAM_REPO/compare/${pin}...main" \
+  --jq '([(.truncated // false | tostring), (.files // [] | length | tostring)] | join(" ")),
+        (.files[]?.filename)' 2>&1)" \
+  || { echo "ERROR: gh api compare against $UPSTREAM_REPO failed: $compare_output" >&2; exit 1; }
+
+meta_line="$(printf '%s\n' "$compare_output" | head -1)"
+truncated="$(printf '%s' "$meta_line" | cut -d' ' -f1)"
+files_count="$(printf '%s' "$meta_line" | cut -d' ' -f2)"
+changed_files="$(printf '%s\n' "$compare_output" | tail -n +2)"
+
+# GitHub's compare-two-commits API caps the `files` array (observed cap: 300 entries) and does
+# not expose Link-header pagination over it, so `--paginate` cannot recover files past the cap.
+# Treat both an explicit `.truncated: true` and hitting the observed cap as truncation, since a
+# capped-but-unflagged response is otherwise indistinguishable from "no changes past this point".
+truncation_suspected=0
+if [[ "$truncated" == "true" ]] || [[ "$files_count" -ge 300 ]]; then
+  truncation_suspected=1
+fi
 
 drift_found=0
 
@@ -98,6 +123,13 @@ while IFS='|' read -r skill prefix; do
     echo "DRIFT: $skill — $count changed path(s) under $prefix: $joined"
   fi
 done <<< "$mapping"
+
+if [[ "$truncation_suspected" -eq 1 ]]; then
+  # Report even when DRIFT lines were already found above — a truncated compare means paths
+  # beyond the cap were never checked, so "no further drift" can't be claimed either way.
+  echo "WARNING: compare result may be truncated (files returned: $files_count, pin: $pin) — GitHub's compare API caps the files list around 300 entries with no further pagination. Drift may exist under paths not covered above; update the pin (docs/WORKFLOW.md §8) and re-run, or review manually against a local clone."
+  exit 1
+fi
 
 if [[ "$drift_found" -eq 0 ]]; then
   echo "OK: no upstream changes detected under any mapped skill's source paths (pin: $pin)"


### PR DESCRIPTION
## Summary
Fixes #30.

`check-upstream-drift.sh` used `gh api repos/.../compare/<pin>...main --jq '.files[]?.filename'` to list changed upstream paths. GitHub's compare-two-commits API caps the `files` array (observed cap: 300 entries) and doesn't expose Link-header pagination over it, so a pin old enough to have accumulated >300 changed files anywhere upstream could silently drop files beyond the cap — producing a false `OK: no upstream changes detected` with no indication anything was missed.

### Changes
- `scripts/check-upstream-drift.sh`: now also reads `.truncated` and `.files | length` from the compare response. If either signals truncation (cap threshold: files returned >= 300), it prints a grep-able `WARNING: compare result may be truncated ...` line and exits non-zero instead of `OK:` — even when some `DRIFT:` lines were already found, since a truncated compare means paths beyond the cap were never checked either way. Dropped the previously-present (and non-functional, for this single-object endpoint) `--paginate` flag, and fixed a jq operator-precedence bug found while adding the second `--jq` output branch (comma binds tighter than `|`, so the trailing `(.files[]?.filename)` needed explicit parens on the first branch to stay anchored at the root object).
- `.github/workflows/upstream-drift.yml`: captures the script's exit code without aborting via `set -e` (needed since exit 1 is now also the truncation signal, not just a transport error), adds a `truncated` step output, and opens/comments on the `upstream-drift`-labeled Issue when `truncated == 'true'` too — with a distinct title ("...: automated detection incomplete (truncated compare)") and body explaining that the absence of a `DRIFT:` line doesn't mean clean in this case. A real (non-truncation) script failure still fails the job as before.
- `docs/PLAN.md`: added a Status entry recording the change and the manual verification performed (see below — no live >300-file diff was available against the actual pin to exercise the real code path end-to-end, so the truncation branch was verified with mocked compare output in a scratch copy of the script).

## Checks run (docs/WORKFLOW.md §7)
- `git diff --check` — clean
- `./scripts/check-skill-frontmatter.sh`, `./scripts/check-install-list-sync.sh`, `./scripts/check-links.sh` — OK
- `shellcheck --severity=warning install.sh scripts/*.sh` — clean
- `npx markdownlint-cli2` — 0 issues
- Manual: ran the script live against the real pin (clean, non-truncated `OK:`); verified the `--jq` filter directly against a saved compare response with `jq`; exercised the truncation-detected path with mocked `compare_output` in a scratch copy of the script (confirmed `DRIFT:` + `WARNING:` print together, exit 1); validated the workflow YAML with `python3 -c "import yaml; yaml.safe_load(...)"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)