### PR TITLE
docs: fix rust-ffi / chromium mismatch between PLAN.md and implementation

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -274,10 +274,14 @@ What a move is, `Pin<Ptr>`, `Unpin`, `PhantomPinned`, the self-referential-buffe
 its own recall path, and `rust-async` links here rather than duplicating.
 
 **11. `rust-ffi`** *(94 min + platform extracts)* — `unsafe-deep-dive/ffi/*` plus the
-*general-purpose* parts of `android/interoperability/*` and `chromium/interoperability-with-cpp/*`:
-Rust↔C↔C++ representation and semantic differences, bindgen, the `cxx` bridge model, type mapping,
-and error handling across the boundary. Deliberately extracts the platform-neutral core so it's
-useful outside Android/Chromium.
+*general-purpose* parts of `android/interoperability/*`: Rust↔C↔C++ representation and semantic
+differences, bindgen, the `cxx` bridge model, type mapping, and error handling across the
+boundary. Deliberately extracts the platform-neutral core so it's useful outside Android — the
+`cxx` bridge material comes from android's own C++ interop track (which already covers the
+bridge/genrules mechanics), not from Chromium's `interoperability-with-cpp` pages; the actual
+`source:` frontmatter (and `scripts/check-upstream-drift.sh`'s mapping) never included Chromium
+paths, only `android/interoperability/{with-c,cpp}/**` (issue #31 — this line previously
+implied Chromium was also a source, which it wasn't and isn't).
 
 ### Phase 4 — integration & gap-fill
 


### PR DESCRIPTION
## Summary
Fixes #31.

`docs/PLAN.md`'s Phase 3 description of `rust-ffi` claimed it draws from *general-purpose* parts of both `android/interoperability/*` and `chromium/interoperability-with-cpp/*`. Neither `skills/rust-ffi/SKILL.md`'s `source:` frontmatter Paths nor `scripts/check-upstream-drift.sh`'s skill→path mapping ever included chromium — both only list `android/interoperability/{with-c,cpp}/**`. The skill body itself has no chromium reference anywhere.

Investigated whether `rust-ffi` actually needs chromium content: its `cxx`-bridge material (bindgen vs. `cxx`, the bridge model) is adequately covered by android's own C++ interop track, which `docs/FILE_MAP.md` notes already includes "cxx bridge/genrules" (13 files). So per the issue's own decision tree, the fix is to drop the stale chromium mention from PLAN.md rather than add chromium paths to the frontmatter/drift-check mapping — the three files are now consistent (all only reference android for `rust-ffi`), and Chromium stays a separate, not-yet-built Phase 5 platform track (`rust-chromium`, unrelated to `rust-ffi`), unchanged.

## Checks run (docs/WORKFLOW.md §7)
- `git diff --check` — clean
- `./scripts/check-links.sh` — OK
- `npx markdownlint-cli2` — 0 issues

Not applicable: frontmatter/install-list-sync/shellcheck (no skill frontmatter or install.sh changes — `skills/rust-ffi/SKILL.md` and `scripts/check-upstream-drift.sh` were already correct and untouched by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)