### PR TITLE
chore: remove stray temp/ dir and ignore it going forward

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ ref/comprehensive-rust/
 
 # Serena MCP local project state
 .serena/
+
+# Scratch directory for local, non-repo working files (tool scan logs, drafts from other
+# projects, etc.) — never intended for this distribution; see issue #32.
+temp/


### PR DESCRIPTION
## Summary
Fixes #32.

The working tree had an untracked `temp/` directory containing two files unrelated to this repo's distribution:
- `WORKFLOW.md` — an unrelated subscription-agent-scheduler project's workflow doc (dated 2026-08-13).
- `SCAN.md` — log output from a third-party code-scanning tool run (`[ocr]`-prefixed) against this repo, also not repo content.

`temp/` wasn't in `.gitignore`, so a broad `git add .` could have accidentally staged either. Removed both files (and the now-empty directory) and added `temp/` to `.gitignore`.

## Checks run (docs/WORKFLOW.md §7)
- `git status --short` — clean (no more untracked `temp/`)
- `git diff --check` — clean

Not applicable: frontmatter/install-list-sync/link-check/shellcheck/markdownlint (no skill, install.sh, or docs content changed — only `.gitignore`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)