### PR TITLE
fix: correct 6 minor technical inaccuracies across skills

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -134,6 +134,38 @@ changed path) for the `gh api` call in a scratch copy of the script, confirming 
 (4) validated `.github/workflows/upstream-drift.yml`'s YAML with
 `python3 -c "import yaml; yaml.safe_load(...)"` after the edit.
 
+**Skill accuracy fixes (2026-09-01, issue #33)**: six small, independently-verified defects
+fixed across six skills, none changing scope or `source:` pins:
+- `rust-unsafe-soundness`: the `MaybeUninit` partial-initialization example used
+  `external_data.len()` unclamped as the "bytes initialized" count passed to
+  `from_raw_parts`, while the preceding `zip` loop silently stops at `buf.len()` — for
+  `external_data.len() > buf.len()` the `SAFETY` comment's claim was false and the slice read
+  past what was actually initialized. Fixed with `.min(buf.len())`; verified with
+  `rustc --edition 2021 --crate-type lib` (compiles clean).
+- `rust-pinning`: the simplified `Pin<Ptr>` struct definition and the `impl !Unpin for
+  PhantomPinned {}` snippet (a negative impl, needs `#![feature(negative_impls)]`, not valid on
+  stable) were presented without noting they're simplified/unstable-std-internal pseudocode.
+  Added inline notes on both.
+- `rust-ffi`: the `c"..."` literal was labeled "(Rust 2021+)" as if edition-gated; it's actually
+  gated on Rust **1.77+** (any edition). Corrected.
+- `rust-polymorphism`: the `(value as &dyn Any).downcast_ref::<Concrete>()` downcast pattern
+  relies on trait upcasting coercion, stabilized in Rust 1.86 — pre-1.86 toolchains need a
+  trait-provided `as_any()` method instead. Added the version note and the pre-1.86 fallback.
+- `rust-ownership-and-lifetimes`: three triage-table rows had a `` `error[...]: ...`x`...` ``
+  shape — an inline-code span containing its own un-escaped backtick-wrapped `` `x` `` —
+  which single backticks can't nest (breaks at the first closing backtick). Fixed by
+  wrapping the three cells in double-backtick fences.
+- `rust-async`: Pitfall 1's `sleep_ms(id: u64, duration_ms: u64)` example never used `id` in the
+  body (an unused-variable warning under `rustc`). Renamed to `_id`; verified with
+  `rustc --edition 2021 --crate-type lib` (no warning).
+
+Verification for all six: `git diff --check`, `./scripts/check-skill-frontmatter.sh`,
+`./scripts/check-links.sh`, and `npx markdownlint-cli2` all clean; each skill still within the
+500-line hard budget (range 138–234 lines post-edit). Manual holistic re-check against the four
+`/skill-stocktake` checklist dimensions (content overlap, `MEMORY.md`/`CLAUDE.md` overlap,
+technical-reference freshness, scope fit) for these six specific skills: all **Keep** — each
+change is a narrow accuracy correction with no scope, delineation, or overlap impact.
+
 Source map: [`FILE_MAP.md`](./FILE_MAP.md). Goal: turn Google's Comprehensive Rust course into
 a set of Claude Code **skills** (`SKILL.md` + `references/`), each scoped tightly enough to
 load fast and stay focused, together covering the course's teaching value — not a transcription

--- a/skills/rust-async/SKILL.md
+++ b/skills/rust-async/SKILL.md
@@ -37,7 +37,7 @@ concurrently.
 ```rust
 // BUG: std::thread::sleep blocks the OS thread; join_all "runs" 10 sleeps
 // one after another instead of concurrently.
-async fn sleep_ms(id: u64, duration_ms: u64) {
+async fn sleep_ms(_id: u64, duration_ms: u64) {
     std::thread::sleep(Duration::from_millis(duration_ms));  // ← blocking!
 }
 join_all((1..=10).map(|t| sleep_ms(t, t * 10))).await;

--- a/skills/rust-ffi/SKILL.md
+++ b/skills/rust-ffi/SKILL.md
@@ -74,7 +74,8 @@ let rust_repr = (b"Hello, Rust", 11);     // Rust: pointer + length, no NUL requ
 let c: &str = unsafe { std::ffi::CStr::from_ptr(ptr).to_str().unwrap() };
 
 // Rust → C: Rust strings aren't NUL-terminated by default — use CString/CStr,
-// or the `c"..."` literal (Rust 2021+) which appends the NUL for you: c"Rust" == b"Rust\0"
+// or the `c"..."` literal (Rust 1.77+, any edition) which appends the NUL for you:
+// c"Rust" == b"Rust\0"
 ```
 
 Checklist:

--- a/skills/rust-ownership-and-lifetimes/SKILL.md
+++ b/skills/rust-ownership-and-lifetimes/SKILL.md
@@ -27,9 +27,9 @@ violation of one of them:
 
 | Compiler message / code | Which rule | Typical fix |
 |---|---|---|
-| `error[E0502]: cannot borrow `x` as mutable because it is also borrowed as immutable` | Aliasing | End the shared borrow before creating the mutable one (see NLL below), or restructure so only one reference is live at a time. |
-| `error[E0499]: cannot borrow `x` as mutable more than once` | Aliasing | You have two `&mut` at once — pass one by value/consume it, or scope them so they don't overlap. |
-| `error[E0597]: `x` does not live long enough` / borrowed value dropped while still borrowed | Outlives | The referent is dropped before the reference is used. Extend the referent's lifetime (move it up a scope) or stop borrowing (clone, or restructure ownership). |
+| ``error[E0502]: cannot borrow `x` as mutable because it is also borrowed as immutable`` | Aliasing | End the shared borrow before creating the mutable one (see NLL below), or restructure so only one reference is live at a time. |
+| ``error[E0499]: cannot borrow `x` as mutable more than once`` | Aliasing | You have two `&mut` at once — pass one by value/consume it, or scope them so they don't overlap. |
+| ``error[E0597]: `x` does not live long enough`` / borrowed value dropped while still borrowed | Outlives | The referent is dropped before the reference is used. Extend the referent's lifetime (move it up a scope) or stop borrowing (clone, or restructure ownership). |
 | `error[E0106]: missing lifetime specifier` | Elision failed | Rust's elision rules (below) couldn't infer one — annotate explicitly. |
 | "cannot move out of `x` because it is borrowed" | Aliasing + move | You're trying to move a value while a reference to it is alive. Clone, or drop the reference first. |
 | Iterator invalidation (`vec.push` while iterating `&vec`) | Aliasing | Mutating a collection while holding references into it can reallocate and dangle those references — collect changes into a separate buffer, then apply them after the loop, or use indices instead of references. |

--- a/skills/rust-pinning/SKILL.md
+++ b/skills/rust-pinning/SKILL.md
@@ -44,6 +44,8 @@ out**. No new compiler magic; it's an API design constraint enforced by ownershi
 way any other type enforces its own invariants by controlling its public surface.
 
 ```rust
+// Simplified — the real std definition has a private field and extra bounds/methods; this
+// captures the shape that matters here.
 #[repr(transparent)]
 pub struct Pin<Ptr> { pointer: Ptr }
 
@@ -83,6 +85,9 @@ for:
 - Some FFI wrapper types around C++ objects that are inherently address-sensitive
 
 ```rust
+// This is std's own (unstable) implementation, shown for how the opt-out works — `impl !Trait`
+// (negative impl) needs #![feature(negative_impls)] and isn't available on stable Rust. You
+// can't write this yourself; use `PhantomPinned` as a field instead, as shown below.
 pub struct PhantomPinned;
 impl !Unpin for PhantomPinned {}
 ```

--- a/skills/rust-polymorphism/SKILL.md
+++ b/skills/rust-polymorphism/SKILL.md
@@ -67,7 +67,9 @@ plain by-value type or generic parameter without `?Sized`.
 - **Downcasting requires `Any`**: to get a concrete type back out of a `dyn Trait`, the trait
   needs `Any` as a supertrait (`trait Foo: Any {}`), and you still cast through `dyn Any`
   explicitly (`(value as &dyn Any).downcast_ref::<Concrete>()`), not through `dyn Foo`
-  directly.
+  directly. That `as &dyn Any` cast relies on trait upcasting coercion, stable since Rust 1.86
+  — on older toolchains, add `fn as_any(&self) -> &dyn Any { self }` to the trait instead and
+  call that.
 - **Pitfall: reaching for `dyn Trait` too early.** Coming from OOP, it's tempting to make
   everything dynamically dispatched by default. This has a real cost — every call pays vtable
   indirection, and worse, patterns like "downcast to compare/combine two trait objects of

--- a/skills/rust-unsafe-soundness/SKILL.md
+++ b/skills/rust-unsafe-soundness/SKILL.md
@@ -148,7 +148,8 @@ anyway**:
 
 ```rust
 let mut buf = [const { MaybeUninit::<u8>::uninit() }; 2048];   // no zeroing cost
-let len = external_data.len();
+let len = external_data.len().min(buf.len());   // `zip` below stops at buf.len() bytes —
+                                                 // `len` must match, or the SAFETY claim is false
 for (dest, src) in buf.iter_mut().zip(external_data) {
     dest.write(*src);                     // write() is always safe on MaybeUninit
 }


### PR DESCRIPTION
## Summary
Fixes #33.

Six independently-verified accuracy fixes across six skills (no scope changes, no `source:` pin changes):

1. **rust-unsafe-soundness** — the `MaybeUninit` partial-initialization example used `external_data.len()` unclamped as the count passed to `from_raw_parts`, while the loop above only initializes up to `buf.len()` bytes. For `external_data.len() > buf.len()` the `SAFETY` comment's claim was false and the resulting slice read past what was actually initialized (soundness bug in a skill specifically about soundness). Fixed with `.min(buf.len())`.
2. **rust-pinning** — the simplified `Pin<Ptr>` struct and the `impl !Unpin for PhantomPinned {}` snippet (a negative impl, needs `#![feature(negative_impls)]`) were presented without noting they're simplified/unstable std-internal pseudocode, not code a reader can write on stable. Added inline notes.
3. **rust-ffi** — the `c"..."` literal was labeled "(Rust 2021+)" as if edition-gated; it's actually gated on the Rust **version** (1.77+), usable on any edition. Corrected.
4. **rust-polymorphism** — the `(value as &dyn Any).downcast_ref::<Concrete>()` pattern relies on trait upcasting coercion, stabilized in Rust **1.86**. Pre-1.86 toolchains need a trait-provided `as_any()` method instead — added the version note and the fallback.
5. **rust-ownership-and-lifetimes** — three triage-table cells had an un-escaped nested single-backtick span (a code span like "error[E0502]: cannot borrow `x` as mutable..." wrapped in single backticks around its own inner `x` backticks), which breaks Markdown rendering since single backticks can't nest. Fixed by wrapping those three cells in double-backtick fences.
6. **rust-async** — Pitfall 1's `sleep_ms(id: u64, duration_ms: u64)` never used `id` in the body (an unused-variable warning under `rustc`). Renamed to `_id`.

## Verification
- The two functional-code changes (#1 and #6) were compiled with `rustc --edition 2021 --crate-type lib` — #1 compiles clean, #6 no longer warns (confirmed the warning was present before the fix).
- `git diff --check`, `./scripts/check-skill-frontmatter.sh`, `./scripts/check-links.sh`, `npx markdownlint-cli2` — all clean.
- Each skill still within the 500-line hard budget (range 138–234 lines post-edit).
- Manual re-check against the four `/skill-stocktake` checklist dimensions for these six skills, recorded in `docs/PLAN.md`: all **Keep** — every change is a narrow accuracy correction with no scope/delineation/overlap impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
