### PR TITLE
fix: reject path-traversal skill names in install.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,20 @@ jobs:
           mkdir -p /tmp/rsc-traversal-canary
           touch /tmp/rsc-traversal-canary/marker
           for bad_name in ".." "../../etc" "a/b" "."; do
-            if ./install.sh --dest /tmp/rsc-traversal-test --force "$bad_name"; then
+            out="$(./install.sh --dest /tmp/rsc-traversal-test --force "$bad_name" 2>&1)" && rc=0 || rc=$?
+            if [[ $rc -eq 0 ]]; then
               echo "expected non-zero exit for skill name: $bad_name" >&2
+              exit 1
+            fi
+            # Assert the *new* guard's own message fired, not just any non-zero exit —
+            # some of these names (e.g. "..") are also independently blocked by rm's own
+            # "refusing to remove '.' or '..'" guard, or by the pre-existing "no such
+            # skill" check for a name that never resolves to a real directory, so a bare
+            # exit-code check here would still pass green even with the guard removed
+            # (code review on PR #51 caught this).
+            if [[ "$out" != *"invalid skill name"* ]]; then
+              echo "expected the path-traversal guard's own error for skill name: $bad_name" >&2
+              echo "$out" >&2
               exit 1
             fi
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,17 @@ jobs:
         run: ./install.sh --dest /tmp/rsc-install-test --force rust-api-design
       - name: installed file is present and non-empty
         run: test -s /tmp/rsc-install-test/.claude/skills/rust-api-design/SKILL.md
+      - name: reject path-traversal skill names (issue #44)
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/rsc-traversal-canary
+          touch /tmp/rsc-traversal-canary/marker
+          for bad_name in ".." "../../etc" "a/b" "."; do
+            if ./install.sh --dest /tmp/rsc-traversal-test --force "$bad_name"; then
+              echo "expected non-zero exit for skill name: $bad_name" >&2
+              exit 1
+            fi
+          done
+          # The canary must survive every attempt above — a regression here means a
+          # traversal name reached rm -rf instead of being rejected up front.
+          test -f /tmp/rsc-traversal-canary/marker

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -186,6 +186,19 @@ sandbox victim directory survives. Added a CI regression step to `install-smoke-
 (`.github/workflows/ci.yml`) that asserts `..`, `../../etc`, `a/b`, and `.` are all rejected
 (non-zero exit) and that a canary file outside the install dest survives every attempt.
 
+**PR #51 code review (docs/WORKFLOW.md §9.1) caught a real gap in that CI step**: a bare
+non-zero-exit assertion for those four specific names doesn't actually exercise the new guard —
+`..` and `.` are independently blocked by `rm`'s own `.`/`..` refusal, and `../../etc`/`a/b`
+independently fail the pre-existing "no such skill" check (`[[ ! -d "$src" ]]`) at the shallow
+`--dest /tmp/rsc-traversal-test` depth the test used, since neither resolves to a real
+directory there. The test would have stayed green even with the new `case` guard fully removed.
+Fixed by asserting the guard's own `"invalid skill name"` message appears in the output, not
+just a non-zero exit code. Verified the fix to the test itself two ways: (1) ran it against the
+patched `install.sh` — passes; (2) surgically removed the `case` guard from a scratch copy of
+`install.sh` (restored from a backup immediately after), re-ran the same four-name loop in
+place — every name now correctly fails the "guard message absent" assertion, proving the
+strengthened test actually catches the guard being reverted.
+
 Source map: [`FILE_MAP.md`](./FILE_MAP.md). Goal: turn Google's Comprehensive Rust course into
 a set of Claude Code **skills** (`SKILL.md` + `references/`), each scoped tightly enough to
 load fast and stay focused, together covering the course's teaching value — not a transcription

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -166,6 +166,26 @@ Verification for all six: `git diff --check`, `./scripts/check-skill-frontmatter
 technical-reference freshness, scope fit) for these six specific skills: all **Keep** — each
 change is a narrow accuracy correction with no scope, delineation, or overlap impact.
 
+**Security fix: install.sh path traversal (2026-09-01, issue #44)**: `install.sh` built
+`src`/`target` paths by directly concatenating `$SKILLS_SRC`/`$DEST` with each positional skill
+name, with no validation. A name containing `..` could make either path resolve outside its
+intended root; combined with `--force`'s `rm -rf "$target"`, this allowed deleting an arbitrary
+directory the process could write to. A literal single `..` segment happens to be blocked by
+`rm`'s own "refusing to remove '.' or '..'" guard (confirmed on the real system: `./install.sh
+--global --force ..` exits 0 but the `rm` itself fails) — but a longer traversal whose final
+path segment isn't literally `..` (e.g. enough leading `../` to overshoot the filesystem root,
+followed by an arbitrary absolute path) bypasses that guard entirely. Reproduced destructively
+in a throwaway sandbox (outside the repo, cleaned up after): built a minimal reproduction of
+`install.sh`'s exact src/target/rm logic pointed at sandboxed `SKILLS_SRC`/`DEST`, and confirmed
+an unrelated sandbox directory was actually deleted by the unpatched logic. Fixed by rejecting
+any skill name that is empty, `.`, `..`, or contains `/` before `src`/`target` are built (a
+`case` guard at the top of the install loop, reusing the existing `not_found`-counter exit-code
+path from issue #25 rather than adding a new early-exit branch). Re-ran the same sandboxed
+reproduction against the patched script: the traversal name is now rejected up front and the
+sandbox victim directory survives. Added a CI regression step to `install-smoke-test`
+(`.github/workflows/ci.yml`) that asserts `..`, `../../etc`, `a/b`, and `.` are all rejected
+(non-zero exit) and that a canary file outside the install dest survives every attempt.
+
 Source map: [`FILE_MAP.md`](./FILE_MAP.md). Goal: turn Google's Comprehensive Rust course into
 a set of Claude Code **skills** (`SKILL.md` + `references/`), each scoped tightly enough to
 load fast and stay focused, together covering the course's teaching value — not a transcription

--- a/install.sh
+++ b/install.sh
@@ -127,6 +127,19 @@ installed=0
 skipped=0
 not_found=0
 for name in "${SELECTED[@]}"; do
+    # Reject anything that isn't a plain directory name *before* it's used to build src/target
+    # below — a name containing '/' or '..' can walk src/target outside SKILLS_SRC/DEST
+    # entirely (arbitrary-path `rm -rf` under --force, since neither rm nor cp validates
+    # containment; a single ".." segment is blocked by rm's own "refusing to remove '.' or
+    # '..'" guard, but a longer traversal isn't — issue #44).
+    case "$name" in
+        ''|.|..|*/*)
+            echo "  ✗ $name — invalid skill name (must be a plain directory name: no '/', '.', or '..')" >&2
+            not_found=$((not_found + 1))
+            continue
+            ;;
+    esac
+
     src="$SKILLS_SRC/$name"
     if [[ ! -d "$src" ]]; then
         echo "  ✗ $name — no such skill in $SKILLS_SRC (see --list)" >&2


### PR DESCRIPTION
## Summary
Fixes #44 (P0/security).

`install.sh` built `src`/`target` paths by directly concatenating `$SKILLS_SRC`/`$DEST` with each positional skill-name argument, with no validation. A name containing `..` could make either path resolve outside its intended root; combined with `--force`'s `rm -rf "$target"`, this allowed deleting an arbitrary directory the process could write to.

A literal single `..` segment happens to be blocked by `rm`'s own '.'/'..' guard (confirmed on the real system: `./install.sh --global --force ..` exits 0 but `rm` itself refuses) — but a longer traversal whose final path segment isn't literally `..` (enough leading `../` to overshoot the filesystem root, then an arbitrary absolute path) bypasses that guard entirely. I reproduced this destructively in a throwaway sandbox outside the repo (built a minimal copy of `install.sh`'s exact src/target/rm logic pointed at sandboxed dirs) and confirmed an unrelated sandbox directory was actually deleted by the unpatched logic.

### Fix
Rejects any skill name that is empty, `.`, `..`, or contains `/` — checked immediately at the top of the install loop, before `src`/`target` are ever built. Invalid names feed into the existing `not_found` counter (same exit-code path as issue #25's "no such skill" case) rather than adding a new early-exit branch.

### Verification
- Re-ran the same sandboxed reproduction against the patched script: the traversal name is now rejected up front and the sandbox victim directory survives.
- Manually tested `..`, `../../etc`, normal names, symlink/copy modes, skip-without-force, and `--force` overwrite (docs/WORKFLOW.md §5 smoke test) — all behave correctly.
- Added a CI regression step to `install-smoke-test` in `.github/workflows/ci.yml` asserting `..`, `../../etc`, `a/b`, and `.` are all rejected (non-zero exit) and a canary file outside the install dest survives every attempt.

## Checks run (docs/WORKFLOW.md §5, §7)
- `shellcheck --severity=warning install.sh scripts/*.sh` — clean
- `git diff --check` — clean
- `./scripts/check-skill-frontmatter.sh`, `./scripts/check-install-list-sync.sh`, `./scripts/check-links.sh` — OK
- `npx markdownlint-cli2` — 0 issues
- Manual install.sh smoke test (§5: list / copy install / symlink install / skip-without-force / force overwrite) — all pass
- `python3 -c "import yaml; yaml.safe_load(...)"` on the modified `ci.yml` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)