### PR TITLE
feat: add installer completion summary and pause

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,68 @@ jobs:
         run: ./install.sh --dest /tmp/rsc-install-test --force rust-api-design
       - name: installed file is present and non-empty
         run: test -s /tmp/rsc-install-test/.claude/skills/rust-api-design/SKILL.md
+      - name: "completion summary and pause behavior (issue #52)"
+        run: |
+          set -euo pipefail
+
+          assert_contains() {
+            if [[ "$1" != *"$2"* ]]; then
+              echo "expected output to contain: $2" >&2
+              echo "$1" >&2
+              exit 1
+            fi
+          }
+
+          test_root="$(mktemp -d)"
+          repo_dir="$PWD"
+
+          custom_dir="$test_root/custom"
+          custom_output="$(./install.sh --dest "$custom_dir" rust-api-design)"
+          assert_contains "$custom_output" "Status: Installation complete"
+          assert_contains "$custom_output" "Destination: $custom_dir/.claude/skills"
+          assert_contains "$custom_output" "Mode: copy"
+          assert_contains "$custom_output" $'Installed (1):\n  - rust-api-design\nSkipped (0): none\nFailed (0): none'
+
+          skip_output="$(./install.sh --dest "$custom_dir" rust-api-design)"
+          assert_contains "$skip_output" $'Installed (0): none\nSkipped (1):\n  - rust-api-design\nFailed (0): none'
+
+          global_home="$test_root/home"
+          global_output="$(HOME="$global_home" ./install.sh --global rust-pinning)"
+          assert_contains "$global_output" "Destination: $global_home/.claude/skills"
+
+          project_dir="$test_root/project"
+          mkdir -p "$project_dir"
+          project_output="$(cd "$project_dir" && "$repo_dir/install.sh" rust-polymorphism)"
+          assert_contains "$project_output" "Destination: $project_dir/.claude/skills"
+
+          mixed_dir="$test_root/mixed"
+          mixed_rc=0
+          mixed_output="$(./install.sh --dest "$mixed_dir" rust-ffi no-such-skill 2>&1)" || mixed_rc=$?
+          if [[ $mixed_rc -ne 1 ]]; then
+            echo "expected mixed valid/invalid install to exit 1, got $mixed_rc" >&2
+            exit 1
+          fi
+          assert_contains "$mixed_output" "Status: Installation failed"
+          assert_contains "$mixed_output" $'Installed (1):\n  - rust-ffi\nSkipped (0): none\nFailed (1):\n  - no-such-skill'
+
+          pause_output="$(printf '\n' | ./install.sh --pause --dest "$test_root/pause" rust-async)"
+          assert_contains "$pause_output" "Status: Installation complete"
+          assert_contains "$pause_output" "Press Enter to close..."
+
+          eof_output="$(./install.sh --pause --dest "$test_root/eof" rust-newtype-and-raii </dev/null 2>&1)"
+          assert_contains "$eof_output" "warning: --pause requested but stdin reached EOF; continuing without waiting."
+
+          failed_pause_rc=0
+          failed_pause_output="$(printf '\n' | ./install.sh --pause --dest "$test_root/failed-pause" no-such-skill 2>&1)" || failed_pause_rc=$?
+          if [[ $failed_pause_rc -ne 1 ]]; then
+            echo "expected paused invalid install to exit 1, got $failed_pause_rc" >&2
+            exit 1
+          fi
+          assert_contains "$failed_pause_output" "Status: Installation failed"
+          assert_contains "$failed_pause_output" "Press Enter to close..."
+
+          help_output="$(./install.sh --help)"
+          assert_contains "$help_output" "--pause"
       - name: reject path-traversal skill names (issue #44)
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,16 @@ jobs:
           assert_contains "$failed_pause_output" "Status: Installation failed"
           assert_contains "$failed_pause_output" "Press Enter to close..."
 
+          failed_pause_eof_rc=0
+          failed_pause_eof_output="$(./install.sh --pause --dest "$test_root/failed-pause-eof" no-such-skill </dev/null 2>&1)" || failed_pause_eof_rc=$?
+          if [[ $failed_pause_eof_rc -ne 1 ]]; then
+            echo "expected paused invalid install with EOF to exit 1, got $failed_pause_eof_rc" >&2
+            exit 1
+          fi
+          assert_contains "$failed_pause_eof_output" "Status: Installation failed"
+          assert_contains "$failed_pause_eof_output" "Press Enter to close..."
+          assert_contains "$failed_pause_eof_output" "warning: --pause requested but stdin reached EOF; continuing without waiting."
+
           help_output="$(./install.sh --help)"
           assert_contains "$help_output" "--pause"
       - name: reject path-traversal skill names (issue #44)

--- a/README.md
+++ b/README.md
@@ -84,11 +84,29 @@ content without re-running the script:
 ./install.sh --list              # show all available skills with their descriptions
 ./install.sh --dest /some/path   # install into <path>/.claude/skills instead of cwd/global
 ./install.sh --force ...         # overwrite an existing install of the same skill(s)
+./install.sh --pause --global    # wait for Enter after the final summary
 ./install.sh --help
 ```
 
 Re-running is always safe: existing installs are skipped unless you pass `--force`; symlink
 installs need no re-run at all to pick up edits.
+
+A completed install ends with a summary showing the result, destination, mode, and the exact
+skills installed, skipped, or rejected:
+
+```text
+Status: Installation complete
+Destination: /path/to/project/.claude/skills
+Mode: copy
+Installed (1):
+  - rust-api-design
+Skipped (0): none
+Failed (0): none
+```
+
+Use `--pause` when launching the installer from a window that closes as soon as the command
+finishes. It waits for Enter after printing the summary. Without `--pause`, the installer remains
+non-interactive for normal terminal, pipe, and CI use.
 
 ### Manual install
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -44,6 +44,15 @@ eval against the course's own exercises/solutions is now piloted for 2 exercises
 entry below and `docs/eval/README.md` — with several mapped exercises still deferred to a
 follow-up. Phase 4 is done for what's in-scope for this repo — see the entry below.
 
+**Installer completion feedback (2026-09-03, issue #52)**: retained the existing start/progress
+output and replaced its terse final `Done` line with a result summary that repeats the destination
+and mode and groups the exact installed, skipped, and failed skill names. Added opt-in `--pause`
+for launchers whose terminal window closes immediately after the command; ordinary CLI/CI runs
+remain non-interactive, and EOF does not turn the pause into a hang or change the install result's
+exit status. README, the `--help` usage block, the manual workflow, and CI smoke assertions are
+kept in sync. This is an installer-only change: no skill content, source pin, attribution, or
+delineation changed.
+
 **CI hardening (2026-08-31, issues #1–#3)**: closed a real gap in `skill-frontmatter` —
 the script checked presence of frontmatter keys but never caught the actual `rust-pinning`
 regression class above (a `: ` inside an unquoted YAML `description:` value truncates it);

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -1,6 +1,6 @@
 # rust-skills-comprehensive 開発ワークフロー
 
-**最終更新:** 2026-08-29
+**最終更新:** 2026-09-03
 **対象:** `rust-skills-comprehensive` — Comprehensive Rustから派生したClaude Code skill集
 
 この文書は、このリポジトリでskillの追加・更新・`install.sh`の変更を行う際に、内容と
@@ -158,12 +158,17 @@ Validateで見つかった問題を修正し、同じ確認を再実行する。
 ./install.sh --dest /tmp/rsc-install-test --symlink <name>  # symlink install
 ./install.sh --dest /tmp/rsc-install-test <name>      # 既存install（--forceなし）がskipされるか
 ./install.sh --dest /tmp/rsc-install-test --force <name>    # --forceでの上書き
-rm -rf /tmp/rsc-install-test
+./install.sh --dest /tmp/rsc-install-test <name> no-such-skill  # 部分成功をsummary後にexit 1で返すか
+printf '\n' | ./install.sh --pause --dest /tmp/rsc-install-pause-test <name>  # summary後にEnterを待つか
+./install.sh --pause --dest /tmp/rsc-install-pause-eof-test <name> </dev/null # EOFでもhangしないか
+rm -rf /tmp/rsc-install-test /tmp/rsc-install-pause-test /tmp/rsc-install-pause-eof-test
 ```
 
 同じ手順は`.github/workflows/ci.yml`の`install-smoke-test` jobでも`rust-api-design`を対象に
-自動実行される（CIの実行環境で完結し、開発者のhome/globalなskill installには触れない）。
-push/PRで自動的に再確認されるが、ローカルでも変更直後に一度手で流す。
+自動実行される。project / custom / 一時`HOME`を使うglobal scopeの最終summary、copy / symlink、
+skip、valid + invalidの部分成功、`--pause`、stdin EOF、exit statusをassertし、CIの実行環境で
+完結するため開発者のhome/globalなskill installには触れない。push/PRで自動的に再確認されるが、
+ローカルでも変更直後に一度手で流す。
 
 `shellcheck --severity=warning install.sh scripts/*.sh`もCIの`shellcheck` jobで実行される
 （info levelの指摘、例: `ls`より`find`を推奨、は対象外——このworkflow変更のために

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,7 @@
 #   ./install.sh rust-api-design rust-async     # install only the named skills
 #   ./install.sh --global rust-pinning          # combine scope + selection
 #   ./install.sh --symlink                # symlink instead of copy (repo devs: live-edit)
+#   ./install.sh --pause                  # wait for Enter after the final summary
 #   ./install.sh --list                   # list available skills and exit
 #   ./install.sh --force ...              # overwrite an existing install of the same skill
 #
@@ -26,10 +27,11 @@ SKILLS_SRC="$SCRIPT_DIR/skills"
 MODE="copy"          # copy | symlink
 DEST=""              # resolved target .../.claude/skills directory
 FORCE=0
+PAUSE=0
 SELECTED=()
 
 usage() {
-    sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+    sed -n '2,21p' "$0" | sed 's/^# \{0,1\}//'
 }
 
 list_skills() {
@@ -75,6 +77,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --force)
             FORCE=1
+            shift
+            ;;
+        --pause)
+            PAUSE=1
             shift
             ;;
         --list)
@@ -126,6 +132,9 @@ echo
 installed=0
 skipped=0
 not_found=0
+INSTALLED_NAMES=()
+SKIPPED_NAMES=()
+FAILED_NAMES=()
 for name in "${SELECTED[@]}"; do
     # Reject anything that isn't a plain directory name *before* it's used to build src/target
     # below — a name containing '/' or '..' can walk src/target outside SKILLS_SRC/DEST
@@ -136,6 +145,7 @@ for name in "${SELECTED[@]}"; do
         ''|.|..|*/*)
             echo "  ✗ $name — invalid skill name (must be a plain directory name: no '/', '.', or '..')" >&2
             not_found=$((not_found + 1))
+            FAILED_NAMES+=("$name")
             continue
             ;;
     esac
@@ -144,6 +154,7 @@ for name in "${SELECTED[@]}"; do
     if [[ ! -d "$src" ]]; then
         echo "  ✗ $name — no such skill in $SKILLS_SRC (see --list)" >&2
         not_found=$((not_found + 1))
+        FAILED_NAMES+=("$name")
         continue
     fi
 
@@ -152,6 +163,7 @@ for name in "${SELECTED[@]}"; do
         if [[ $FORCE -eq 0 ]]; then
             echo "  – $name — already exists, skipping (use --force to overwrite)"
             skipped=$((skipped + 1))
+            SKIPPED_NAMES+=("$name")
             continue
         fi
         rm -rf "$target"
@@ -164,16 +176,60 @@ for name in "${SELECTED[@]}"; do
     fi
     echo "  ✓ $name"
     installed=$((installed + 1))
+    INSTALLED_NAMES+=("$name")
 done
 
-echo
-echo "Done: $installed installed, $skipped skipped."
-if [[ "$SCOPE" == "project" ]]; then
-    echo "Installed to the project you ran this from: $DEST"
-    echo "Re-run from a different project directory, or with --global, as needed."
+exit_status=0
+if [[ $not_found -gt 0 ]]; then
+    exit_status=1
 fi
 
-if [[ $not_found -gt 0 ]]; then
-    echo "error: $not_found skill name(s) did not match any directory under $SKILLS_SRC (see --list)" >&2
-    exit 1
+echo
+if [[ $exit_status -eq 0 ]]; then
+    echo "Status: Installation complete"
+else
+    echo "Status: Installation failed"
 fi
+echo "Destination: $DEST"
+echo "Mode: $MODE"
+
+if [[ $installed -eq 0 ]]; then
+    echo "Installed (0): none"
+else
+    echo "Installed ($installed):"
+    for name in "${INSTALLED_NAMES[@]}"; do
+        echo "  - $name"
+    done
+fi
+
+if [[ $skipped -eq 0 ]]; then
+    echo "Skipped (0): none"
+else
+    echo "Skipped ($skipped):"
+    for name in "${SKIPPED_NAMES[@]}"; do
+        echo "  - $name"
+    done
+fi
+
+if [[ $not_found -eq 0 ]]; then
+    echo "Failed (0): none"
+else
+    echo "Failed ($not_found):"
+    for name in "${FAILED_NAMES[@]}"; do
+        echo "  - $name"
+    done
+    echo "error: $not_found skill name(s) did not match any directory under $SKILLS_SRC (see --list)" >&2
+fi
+
+if [[ $PAUSE -eq 1 ]]; then
+    echo
+    printf 'Press Enter to close...'
+    if IFS= read -r _; then
+        echo
+    else
+        echo
+        echo "warning: --pause requested but stdin reached EOF; continuing without waiting." >&2
+    fi
+fi
+
+exit "$exit_status"


### PR DESCRIPTION
## Summary

- replace the terse final `Done` line with a result summary showing status, destination, mode, and exact installed/skipped/failed skill names
- add opt-in `--pause` so users can read the summary before an auto-closing terminal exits, while keeping normal CLI/CI execution non-interactive
- preserve the original install result when stdin reaches EOF, including failed installs, and keep partial valid/invalid installs at exit 1
- synchronize README, `--help`, `docs/PLAN.md`, `docs/WORKFLOW.md`, and CI smoke coverage

Fixes #52.

## Motivation and scope

This implements the installer-completion feedback recorded in `docs/PLAN.md` and Issue #52. The existing start/progress output is retained; only the final result reporting is expanded.

This is installer-only work. It does not change any `SKILL.md`, upstream source pin, attribution, line budget, trigger behavior, or skill delineation. Issue #45's atomic overwrite, empty-skill discovery, and `usage()` refactor remain out of scope.

The Issue #52 plan received the required read-only planning review before implementation. The review found no blocker and required explicit synchronization of `--help` and `docs/WORKFLOW.md`; both are included.

## TDD and verification

- RED: added the summary assertion first; the pre-change installer failed it because `Status: Installation complete` was absent
- GREEN: the same assertion passes after implementation under macOS Bash 3.2.57
- `git diff --check`
- `./scripts/check-skill-frontmatter.sh`
- `./scripts/check-install-list-sync.sh` — 11 skills
- `./scripts/check-links.sh`
- `shellcheck --severity=warning install.sh scripts/*.sh`
- `npx --yes markdownlint-cli2 --config .markdownlint-cli2.jsonc "skills/**/*.md" "docs/**/*.md" "README.md" "CONTRIBUTING.md"` — 20 files, 0 issues
- all `install-smoke-test` run steps executed locally
- manual §5 smoke test: list, copy, symlink, skip, force, valid+invalid exit 1, pause, and EOF
- GitHub Actions: all 6 jobs passed on commit `e4626a9`

`/skill-stocktake` is not applicable because no skill content or trigger metadata changed.

## Review status

- implementation-time diff review: no blocker; strengthened category/name assertions and corrected the PLAN status wording
- post-PR review agent (`origin/main...HEAD`): no findings
- review follow-up: added regression coverage proving failed install + `--pause` + EOF preserves exit 1 (`e4626a9`)
- main ancestry: up to date
- PR state: `MERGEABLE` / `CLEAN`
