### PR TITLE
fix: install.sh stage-then-swap overwrite and empty array guard (#45)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,27 @@ jobs:
         run: ./install.sh --dest /tmp/rsc-install-test rust-api-design
       - name: --force overwrites
         run: ./install.sh --dest /tmp/rsc-install-test --force rust-api-design
+      - name: --force mode transition (copy to symlink, and symlink to copy)
+        run: |
+          set -euo pipefail
+          ./install.sh --dest /tmp/rsc-install-test --force --symlink rust-api-design
+          test -L /tmp/rsc-install-test/.claude/skills/rust-api-design
+          ./install.sh --dest /tmp/rsc-install-test --force rust-api-design
+          test -d /tmp/rsc-install-test/.claude/skills/rust-api-design
+          test ! -L /tmp/rsc-install-test/.claude/skills/rust-api-design
+      - name: reject empty --dest argument
+        run: |
+          set -euo pipefail
+          rc=0
+          out="$(./install.sh --dest "" rust-api-design 2>&1)" || rc=$?
+          if [[ $rc -ne 1 ]]; then
+            echo "expected empty --dest to exit 1, got $rc" >&2
+            exit 1
+          fi
+          if [[ "$out" != *"error: --dest requires a path argument"* ]]; then
+            echo "expected --dest path error message, got: $out" >&2
+            exit 1
+          fi
       - name: installed file is present and non-empty
         run: test -s /tmp/rsc-install-test/.claude/skills/rust-api-design/SKILL.md
       - name: "completion summary and pause behavior (issue #52)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,3 +167,21 @@ jobs:
           # The canary must survive every attempt above — a regression here means a
           # traversal name reached rm -rf instead of being rejected up front.
           test -f /tmp/rsc-traversal-canary/marker
+      - name: empty skills directory exits cleanly with error (issue #45)
+        run: |
+          set -euo pipefail
+          empty_dir="$(mktemp -d)"
+          mkdir -p "$empty_dir/empty_repo/skills"
+          cp install.sh "$empty_dir/empty_repo/"
+          rc=0
+          out="$(cd "$empty_dir/empty_repo" && ./install.sh --dest "$empty_dir/dest" 2>&1)" || rc=$?
+          if [[ $rc -ne 1 ]]; then
+            echo "expected empty skills dir install to exit 1, got $rc" >&2
+            exit 1
+          fi
+          if [[ "$out" != *"error: no skills found in"* ]]; then
+            echo "expected 'error: no skills found in' message, got:" >&2
+            echo "$out" >&2
+            exit 1
+          fi
+          rm -rf "$empty_dir"

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -44,6 +44,15 @@ eval against the course's own exercises/solutions is now piloted for 2 exercises
 entry below and `docs/eval/README.md` — with several mapped exercises still deferred to a
 follow-up. Phase 4 is done for what's in-scope for this repo — see the entry below.
 
+**Installer robustness hardening (2026-09-03, issue #45)**: addressed four installer robustness issues:
+(1) replaced `--force`'s non-atomic `rm -rf` + `cp`/`ln` sequence with a stage-then-swap mechanism
+and trap-backed rollback/cleanup (`.tmp.*` and `.old.*`), ensuring that aborts or copy errors never
+leave existing installs destroyed; (2) added an explicit check after the auto-discovery loop to
+prevent bash < 4.4 `unbound variable` crashes when `"${SELECTED[@]}"` is expanded on an empty array
+under `set -u`; (3) verified `SKILLS_SRC` directory check order remains safe before `mkdir -p "$DEST"`;
+(4) replaced line-numbered `sed` extraction in `usage()` with a self-contained heredoc so `--help`
+does not silently break upon future header edits. CI smoke test assertions added to `ci.yml`.
+
 **Installer completion feedback (2026-09-03, issue #52)**: retained the existing start/progress
 output and replaced its terse final `Done` line with a result summary that repeats the destination
 and mode and groups the exact installed, skipped, and failed skill names. Added opt-in `--pause`

--- a/install.sh
+++ b/install.sh
@@ -104,7 +104,7 @@ while [[ $# -gt 0 ]]; do
             # PROJECT_DIR="$2" and fail later with a raw, confusing error
             # (an unbound-variable crash, or `mkdir: illegal option --`)
             # instead of this script's own usage message (issue #25 review).
-            if [[ $# -lt 2 || "$2" == -* ]]; then
+            if [[ $# -lt 2 || -z "$2" || "$2" == -* ]]; then
                 echo "error: --dest requires a path argument" >&2
                 usage
                 exit 1
@@ -238,16 +238,9 @@ for name in "${SELECTED[@]}"; do
 
     if ! mv "$tmp_target" "$target"; then
         echo "  ✗ $name — failed to activate target" >&2
-        if [[ -n "$backup_target" && ( -e "$backup_target" || -L "$backup_target" ) ]]; then
-            mv "$backup_target" "$target" 2>/dev/null || true
-        fi
-        rm -rf "$tmp_target"
-        if [[ -n "$backup_target" ]]; then
-            rm -rf "$backup_target"
-        fi
-        CURRENT_TMP=""
-        CURRENT_BACKUP=""
-        CURRENT_TARGET=""
+        # Exit directly: cleanup() restores $CURRENT_BACKUP to $CURRENT_TARGET
+        # if target is missing, deletes $CURRENT_TMP, and never deletes
+        # $CURRENT_BACKUP if restoring it fails.
         exit 1
     fi
 

--- a/install.sh
+++ b/install.sh
@@ -30,8 +30,50 @@ FORCE=0
 PAUSE=0
 SELECTED=()
 
+CURRENT_TMP=""
+CURRENT_BACKUP=""
+CURRENT_TARGET=""
+
+cleanup() {
+    if [[ -n "${CURRENT_BACKUP:-}" && ( -e "$CURRENT_BACKUP" || -L "$CURRENT_BACKUP" ) ]]; then
+        if [[ -n "${CURRENT_TARGET:-}" && ! -e "$CURRENT_TARGET" && ! -L "$CURRENT_TARGET" ]]; then
+            mv "$CURRENT_BACKUP" "$CURRENT_TARGET" 2>/dev/null || true
+        else
+            rm -rf "$CURRENT_BACKUP"
+        fi
+    fi
+    if [[ -n "${CURRENT_TMP:-}" && ( -e "$CURRENT_TMP" || -L "$CURRENT_TMP" ) ]]; then
+        rm -rf "$CURRENT_TMP"
+    fi
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 129' HUP
+
 usage() {
-    sed -n '2,21p' "$0" | sed 's/^# \{0,1\}//'
+    cat <<'EOF'
+Install script for rust-skills-comprehensive.
+
+Copies (or symlinks) one or more skills from this repo's skills/ directory
+into a Claude Code skills directory — either a project's .claude/skills/
+or the user's global ~/.claude/skills/.
+
+Usage:
+  ./install.sh                          # install all skills, project-level (./.claude/skills)
+  ./install.sh --global                 # install all skills, global (~/.claude/skills)
+  ./install.sh --dest /path/to/project  # install all skills into <path>/.claude/skills
+  ./install.sh rust-api-design rust-async     # install only the named skills
+  ./install.sh --global rust-pinning          # combine scope + selection
+  ./install.sh --symlink                # symlink instead of copy (repo devs: live-edit)
+  ./install.sh --pause                  # wait for Enter after the final summary
+  ./install.sh --list                   # list available skills and exit
+  ./install.sh --force ...              # overwrite an existing install of the same skill
+
+Re-run any time to pick up updates (add --force to overwrite existing copies;
+symlink installs always reflect the latest content with no re-run needed).
+EOF
 }
 
 list_skills() {
@@ -123,7 +165,12 @@ if [[ ${#SELECTED[@]} -eq 0 ]]; then
     # Avoid `mapfile`/`readarray` (bash 4+ only) — macOS ships bash 3.2 by default.
     while IFS= read -r name; do
         SELECTED+=("$name")
-    done < <(cd "$SKILLS_SRC" && ls -d */ | sed 's#/$##')
+    done < <(cd "$SKILLS_SRC" && ls -d */ 2>/dev/null | sed 's#/$##')
+fi
+
+if [[ ${#SELECTED[@]} -eq 0 ]]; then
+    echo "error: no skills found in $SKILLS_SRC" >&2
+    exit 1
 fi
 
 echo "Installing ${#SELECTED[@]} skill(s) → $DEST  (mode: $MODE)"
@@ -166,14 +213,52 @@ for name in "${SELECTED[@]}"; do
             SKIPPED_NAMES+=("$name")
             continue
         fi
-        rm -rf "$target"
     fi
 
+    # Stage-then-swap: copy or symlink into a temporary path first so that
+    # any failure (e.g. disk full, permission error, Ctrl-C) leaves existing
+    # installs intact.
+    tmp_target="$DEST/.tmp.$name.$RANDOM.$$"
+    backup_target=""
+    CURRENT_TMP="$tmp_target"
+    CURRENT_TARGET="$target"
+    CURRENT_BACKUP=""
+
     if [[ "$MODE" == "symlink" ]]; then
-        ln -s "$src" "$target"
+        ln -s "$src" "$tmp_target"
     else
-        cp -R "$src" "$target"
+        cp -R "$src" "$tmp_target"
     fi
+
+    if [[ -e "$target" || -L "$target" ]]; then
+        backup_target="$DEST/.old.$name.$RANDOM.$$"
+        CURRENT_BACKUP="$backup_target"
+        mv "$target" "$backup_target"
+    fi
+
+    if ! mv "$tmp_target" "$target"; then
+        echo "  ✗ $name — failed to activate target" >&2
+        if [[ -n "$backup_target" && ( -e "$backup_target" || -L "$backup_target" ) ]]; then
+            mv "$backup_target" "$target" 2>/dev/null || true
+        fi
+        rm -rf "$tmp_target"
+        if [[ -n "$backup_target" ]]; then
+            rm -rf "$backup_target"
+        fi
+        CURRENT_TMP=""
+        CURRENT_BACKUP=""
+        CURRENT_TARGET=""
+        exit 1
+    fi
+
+    if [[ -n "$backup_target" && ( -e "$backup_target" || -L "$backup_target" ) ]]; then
+        rm -rf "$backup_target"
+    fi
+
+    CURRENT_TMP=""
+    CURRENT_BACKUP=""
+    CURRENT_TARGET=""
+
     echo "  ✓ $name"
     installed=$((installed + 1))
     INSTALLED_NAMES+=("$name")


### PR DESCRIPTION
## Summary
Fixes #45.

Addressed four installer robustness issues:
1. Replaced `--force`'s non-atomic `rm -rf` + `cp`/`ln` sequence with a stage-then-swap mechanism and trap-backed rollback/cleanup (`.tmp.*` and `.old.*`), ensuring that aborts or copy errors never leave existing installs destroyed.
2. Added an explicit check after the auto-discovery loop to prevent bash < 4.4 `unbound variable` crashes when `"${SELECTED[@]}"` is expanded on an empty array under `set -u`.
3. Verified `SKILLS_SRC` directory check order remains safe before `mkdir -p "$DEST"`.
4. Replaced line-numbered `sed` extraction in `usage()` with a self-contained heredoc so `--help` does not silently break upon future header edits.

## Verification
- Planning review conducted via read-only subagent (§2.1).
- Manual verification of stage-then-swap atomicity: simulated failure during copy and confirmed canary file in target survives intact.
- Manual verification of empty skills dir: verified clean exit with `error: no skills found in ...` and returncode 1, with no bash unbound variable crash.
- Manual verification of `install.sh --help`: verified exact text match.
- Added CI regression step to `install-smoke-test` for empty skills directory.
- Ran all §7 quality gate checks: `shellcheck`, `check-skill-frontmatter.sh`, `check-install-list-sync.sh`, `check-links.sh`, `markdownlint-cli2`.