### PR TITLE
fix: check-skill-frontmatter closing delimiter, quote consistency, and nullglob (#46)

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -44,6 +44,14 @@ eval against the course's own exercises/solutions is now piloted for 2 exercises
 entry below and `docs/eval/README.md` — with several mapped exercises still deferred to a
 follow-up. Phase 4 is done for what's in-scope for this repo — see the entry below.
 
+**Frontmatter validator robustness hardening (2026-09-04, issue #46)**: addressed four validation gaps in
+`scripts/check-skill-frontmatter.sh`: (1) added an explicit check that frontmatter closes with a second `---`
+delimiter line, preventing unclosed files from being parsed through the body; (2) unified the quote-exclusion
+logic so that valid quoted YAML scalar descriptions (e.g. `"Note: foo"`) do not falsely trigger the `: ` check;
+(3) enabled `shopt -s nullglob` and added an explicit check for empty skill directories to prevent literal glob
+expansion and bash < 4.4 unbound variable crashes; (4) replaced `wc -l` with `awk 'END{print NR}'` so line budget
+verification properly counts unterminated final lines.
+
 **Installer robustness hardening (2026-09-03, issue #45)**: addressed four installer robustness issues:
 (1) replaced `--force`'s non-atomic `rm -rf` + `cp`/`ln` sequence with a stage-then-swap mechanism
 and trap-backed rollback/cleanup (`.tmp.*` and `.old.*`), ensuring that aborts or copy errors never

--- a/scripts/check-skill-frontmatter.sh
+++ b/scripts/check-skill-frontmatter.sh
@@ -9,17 +9,31 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SKILLS_DIR="$SCRIPT_DIR/../skills"
+SKILLS_DIR="${SKILLS_DIR:-$SCRIPT_DIR/../skills}"
 MAX_LINES=500
 
 status=0
 
-for skill_md in "$SKILLS_DIR"/*/SKILL.md; do
+shopt -s nullglob
+skills=("$SKILLS_DIR"/*/SKILL.md)
+
+if [[ ${#skills[@]} -eq 0 ]]; then
+  echo "FAIL: no SKILL.md files found under $SKILLS_DIR" >&2
+  exit 1
+fi
+
+for skill_md in "${skills[@]}"; do
   name="$(basename "$(dirname "$skill_md")")"
 
   # Frontmatter must start on line 1 and close with a second '---' line.
   if [[ "$(sed -n '1p' "$skill_md")" != "---" ]]; then
     echo "FAIL: $skill_md — does not start with '---' frontmatter delimiter"
+    status=1
+    continue
+  fi
+
+  if ! awk 'NR>1 && /^---$/ {found=1; exit} END {exit !found}' "$skill_md"; then
+    echo "FAIL: $skill_md — missing closing '---' frontmatter delimiter"
     status=1
     continue
   fi
@@ -44,27 +58,25 @@ for skill_md in "$SKILLS_DIR"/*/SKILL.md; do
   # followed by a space ends the value early no matter where it appears
   # (backticks included) — this previously broke the harness's own
   # frontmatter parser (docs/PLAN.md Status log, rust-pinning defect).
+  # Similarly, a space followed by '#' starts a YAML comment in an unquoted
+  # plain scalar, silently truncating everything after it (issue #24).
+  # Skip both checks if the value is quoted (starts with '"' or "'").
   fm_desc="$(printf '%s\n' "$frontmatter" | sed -n 's/^description: *//p' | head -1)"
-  if [[ "$fm_desc" == *": "* ]]; then
-    echo "FAIL: $skill_md — description contains ': ' (colon+space), which truncates an unquoted YAML value — rewrite to avoid it (docs/WORKFLOW.md §4.2)"
-    status=1
-  fi
-
-  # Same hazard, different character: a space followed by '#' starts a YAML
-  # comment in an unquoted plain scalar, silently truncating everything
-  # after it — this bit rust-unsafe-soundness's description ("...writing a
-  # # Safety doc section...") in exactly the same way as the ': ' case
-  # above (issue #24). Skip this check if the value is already quoted
-  # (starts with a literal '"' or "'"), where '#' has no special meaning.
   case "$fm_desc" in
     '"'*|"'"*) ;;
-    *' #'*)
-      echo "FAIL: $skill_md — description contains ' #' (space+hash), which starts a YAML comment in an unquoted value and truncates everything after it — rewrite to avoid it (docs/WORKFLOW.md §4.2)"
-      status=1
+    *)
+      if [[ "$fm_desc" == *": "* ]]; then
+        echo "FAIL: $skill_md — description contains ': ' (colon+space), which truncates an unquoted YAML value — rewrite to avoid it (docs/WORKFLOW.md §4.2)"
+        status=1
+      fi
+      if [[ "$fm_desc" == *" #"* ]]; then
+        echo "FAIL: $skill_md — description contains ' #' (space+hash), which starts a YAML comment in an unquoted value and truncates everything after it — rewrite to avoid it (docs/WORKFLOW.md §4.2)"
+        status=1
+      fi
       ;;
   esac
 
-  lines="$(wc -l < "$skill_md" | tr -d ' ')"
+  lines="$(awk 'END{print NR}' "$skill_md")"
   if (( lines > MAX_LINES )); then
     echo "FAIL: $skill_md — $lines lines exceeds the ${MAX_LINES}-line budget (docs/WORKFLOW.md §1)"
     status=1


### PR DESCRIPTION
## Summary
Fixes #46.

Addressed four validation gaps in `scripts/check-skill-frontmatter.sh`:
1. Added an explicit check that frontmatter closes with a second `---` delimiter line, preventing unclosed files from being parsed through the body.
2. Unified the quote-exclusion logic so that valid quoted YAML scalar descriptions (e.g. `"Note: foo"`) do not falsely trigger the `: ` check.
3. Enabled `shopt -s nullglob`, stored matches in an array, and added an explicit check for empty skill directories to prevent literal glob expansion and bash < 4.4 unbound variable crashes.
4. Replaced `wc -l` with `awk 'END{print NR}'` so line budget verification properly counts unterminated final lines.

## Verification
- Planning review conducted via read-only subagent (§2.1).
- Missing closing `---` test: confirmed FAIL emitted on missing closing delimiter.
- Quoted description test: confirmed `"Note: this has : and # properly quoted"` passes cleanly.
- Empty skills dir test: confirmed clean exit 1 with explicit diagnostic message when run against an empty directory.
- Unterminated line test: confirmed 501st line without trailing newline triggers line budget exceeded failure.
- Quality gate checks run: `shellcheck`, `check-skill-frontmatter.sh`, `check-install-list-sync.sh`, `check-links.sh`, `markdownlint-cli2`.