### PR TITLE
fix: check-install-list-sync robustness for empty skills, failure capture, and locale (#47)

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -44,6 +44,13 @@ eval against the course's own exercises/solutions is now piloted for 2 exercises
 entry below and `docs/eval/README.md` — with several mapped exercises still deferred to a
 follow-up. Phase 4 is done for what's in-scope for this repo — see the entry below.
 
+**Install-list sync check robustness hardening (2026-09-04, issue #47)**: addressed four robustness issues in
+`scripts/check-install-list-sync.sh`: (1) replaced `ls -d */` with `shopt -s nullglob` and bash 3.2-safe array
+enumeration guarded against empty array expansions under `set -u`; (2) captured `install.sh --list` exit status and
+output, replacing silent pipefail aborts with an explicit `FAIL:` diagnostic message; (3) enforced `export LC_ALL=C`
+and explicit `LC_ALL=C` sort/comm invocations to eliminate locale-dependent collation drift; (4) enhanced `--list`
+parsing with `awk 'NR>1 && NF {print $1}'` to skip empty lines, and allowed test overrides via `SKILLS_DIR` and `INSTALL_SCRIPT`.
+
 **Frontmatter validator robustness hardening (2026-09-04, issue #46)**: addressed four validation gaps in
 `scripts/check-skill-frontmatter.sh`: (1) added an explicit check that frontmatter closes with a second `---`
 delimiter line, preventing unclosed files from being parsed through the body; (2) unified the quote-exclusion

--- a/scripts/check-install-list-sync.sh
+++ b/scripts/check-install-list-sync.sh
@@ -9,27 +9,54 @@
 # Usage: ./scripts/check-install-list-sync.sh
 
 set -euo pipefail
+export LC_ALL=C
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$SCRIPT_DIR/.."
-SKILLS_DIR="$REPO_DIR/skills"
+SKILLS_DIR="${SKILLS_DIR:-$REPO_DIR/skills}"
+INSTALL_SCRIPT="${INSTALL_SCRIPT:-$REPO_DIR/install.sh}"
 
 status=0
 
-dir_names="$(cd "$SKILLS_DIR" && ls -d */ | sed 's#/$##' | sort)"
+if [[ ! -d "$SKILLS_DIR" ]]; then
+  echo "FAIL: skills directory not found: $SKILLS_DIR" >&2
+  exit 1
+fi
+
+shopt -s nullglob
+dirs=("$SKILLS_DIR"/*/)
+dir_names_arr=()
+if [[ ${#dirs[@]} -gt 0 ]]; then
+  for d in "${dirs[@]}"; do
+    dir_names_arr+=("$(basename "$d")")
+  done
+fi
+
+if [[ ${#dir_names_arr[@]} -gt 0 ]]; then
+  dir_names="$(printf '%s\n' "${dir_names_arr[@]}" | LC_ALL=C sort)"
+else
+  dir_names=""
+fi
+
+# Capture install.sh --list output with error handling.
+if ! raw_list="$("$INSTALL_SCRIPT" --list 2>&1)"; then
+  echo "FAIL: 'install.sh --list' execution failed:" >&2
+  echo "$raw_list" >&2
+  exit 1
+fi
 
 # First whitespace-separated column of each "  <name>  <description>" line,
-# skipping the "Available skills:" header.
-list_names="$("$REPO_DIR/install.sh" --list | tail -n +2 | awk '{print $1}' | sort)"
+# skipping the "Available skills:" header and any empty lines.
+list_names="$(printf '%s\n' "$raw_list" | awk 'NR>1 && NF {print $1}' | LC_ALL=C sort)"
 
-missing_from_list="$(comm -23 <(printf '%s\n' "$dir_names") <(printf '%s\n' "$list_names") || true)"
+missing_from_list="$(comm -23 <(if [[ -n "$dir_names" ]]; then printf '%s\n' "$dir_names"; fi) <(if [[ -n "$list_names" ]]; then printf '%s\n' "$list_names"; fi) || true)"
 if [[ -n "$missing_from_list" ]]; then
   echo "FAIL: skill(s) under skills/ missing from 'install.sh --list':"
   echo "$missing_from_list" | sed 's/^/  - /'
   status=1
 fi
 
-missing_dir="$(comm -13 <(printf '%s\n' "$dir_names") <(printf '%s\n' "$list_names") || true)"
+missing_dir="$(comm -13 <(if [[ -n "$dir_names" ]]; then printf '%s\n' "$dir_names"; fi) <(if [[ -n "$list_names" ]]; then printf '%s\n' "$list_names"; fi) || true)"
 if [[ -n "$missing_dir" ]]; then
   echo "FAIL: 'install.sh --list' names skill(s) with no matching skills/ directory:"
   echo "$missing_dir" | sed 's/^/  - /'
@@ -37,7 +64,7 @@ if [[ -n "$missing_dir" ]]; then
 fi
 
 if [[ $status -eq 0 ]]; then
-  count="$(printf '%s\n' "$dir_names" | grep -c .)"
+  count="${#dir_names_arr[@]}"
   echo "OK: install.sh --list matches skills/ ($count skill(s))"
 fi
 


### PR DESCRIPTION
## Summary
Fixes #47.

Addressed four robustness issues in `scripts/check-install-list-sync.sh`:
1. Replaced `ls -d */` with `shopt -s nullglob` and bash 3.2-safe array enumeration guarded against empty array expansions under `set -u`.
2. Captured `install.sh --list` exit status and output, replacing silent pipefail aborts with an explicit `FAIL:` diagnostic message.
3. Enforced `export LC_ALL=C` and explicit `LC_ALL=C` sort/comm invocations to eliminate locale-dependent collation drift.
4. Enhanced `--list` parsing with `awk 'NR>1 && NF {print $1}'` to skip empty lines, and allowed test overrides via `SKILLS_DIR` and `INSTALL_SCRIPT`.

## Verification
- Planning review conducted via read-only subagent (§2.1).
- Empty skills dir test: verified clean exit 0 with `OK: install.sh --list matches skills/ (0 skill(s))` when running against an empty directory.
- Broken installer test: verified clear `FAIL: 'install.sh --list' execution failed:` message and non-zero exit when installer command fails.
- Current repository verification: matches all 11 skills cleanly.
- Quality gate checks run: `shellcheck`, `check-skill-frontmatter.sh`, `check-install-list-sync.sh`, `check-links.sh`, `markdownlint-cli2`.