### PR TITLE
fix: ci workflow permissions, timeouts, concurrency, action pin, and smoke test (#49)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,18 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   shellcheck:
     name: Shellcheck install.sh and scripts/*.sh
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - name: Run shellcheck (warning severity — see docs/WORKFLOW.md §5)
@@ -17,6 +25,7 @@ jobs:
   skill-frontmatter:
     name: Skill frontmatter and line budget
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - name: Check SKILL.md frontmatter and line budget
@@ -25,6 +34,7 @@ jobs:
   install-list-sync:
     name: install.sh --list matches skills/
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - name: Check install.sh --list vs skills/ directories
@@ -33,6 +43,7 @@ jobs:
   link-check:
     name: Skill/docs cross-reference links
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - name: Check relative links and [[name]] references
@@ -41,10 +52,11 @@ jobs:
   markdown-lint:
     name: Markdown lint (heading structure, code fence language)
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - name: Run markdownlint-cli2
-        uses: DavidAnson/markdownlint-cli2-action@v24
+        uses: DavidAnson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff # v24
         with:
           globs: |
             skills/**/*.md
@@ -55,6 +67,7 @@ jobs:
   install-smoke-test:
     name: install.sh smoke test
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - name: --list
@@ -64,9 +77,23 @@ jobs:
       - name: symlink install
         run: ./install.sh --dest /tmp/rsc-install-test-symlink --symlink rust-api-design
       - name: re-run without --force is skipped (no error, no overwrite)
-        run: ./install.sh --dest /tmp/rsc-install-test rust-api-design
+        run: |
+          set -euo pipefail
+          installed_file="/tmp/rsc-install-test/.claude/skills/rust-api-design/SKILL.md"
+          echo "canary modification" >> "$installed_file"
+          checksum="$(sha256sum "$installed_file")"
+          ./install.sh --dest /tmp/rsc-install-test rust-api-design
+          echo "$checksum" | sha256sum -c -
       - name: --force overwrites
-        run: ./install.sh --dest /tmp/rsc-install-test --force rust-api-design
+        run: |
+          set -euo pipefail
+          installed_file="/tmp/rsc-install-test/.claude/skills/rust-api-design/SKILL.md"
+          ./install.sh --dest /tmp/rsc-install-test --force rust-api-design
+          if grep -q "canary modification" "$installed_file"; then
+            echo "expected --force to overwrite canary modification" >&2
+            exit 1
+          fi
+          cmp -s "$installed_file" skills/rust-api-design/SKILL.md
       - name: --force mode transition (copy to symlink, and symlink to copy)
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   shellcheck:
@@ -93,7 +93,7 @@ jobs:
             echo "expected --force to overwrite canary modification" >&2
             exit 1
           fi
-          cmp -s "$installed_file" skills/rust-api-design/SKILL.md
+          cmp "$installed_file" skills/rust-api-design/SKILL.md
       - name: --force mode transition (copy to symlink, and symlink to copy)
         run: |
           set -euo pipefail

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -48,8 +48,9 @@ follow-up. Phase 4 is done for what's in-scope for this repo — see the entry b
 `.github/workflows/ci.yml`: (1) pinned third-party `DavidAnson/markdownlint-cli2-action` to full 40-character
 commit SHA `21c1be1b93ad9ed58fa840aacc3f279cde2a72ff` (`v24`); (2) declared top-level `permissions: contents: read`
 to enforce the principle of least privilege; (3) configured explicit `timeout-minutes` on all 6 jobs (5m for lints/checks,
-10m for smoke test) to avoid hung runners; (4) added a top-level `concurrency` group with `cancel-in-progress: true`
-to cancel superseded runs on rapid pushes; (5) hardened the `install-smoke-test` "no overwrite" verification by appending
+10m for smoke test) to avoid hung runners; (4) added a top-level `concurrency` group with `cancel-in-progress`
+scoped to pull requests (`${{ github.ref != 'refs/heads/main' }}`) to cancel superseded PR runs without breaking main pushes;
+(5) hardened the `install-smoke-test` "no overwrite" verification by appending
 a canary modification, asserting SHA256 checksum identity across skipped re-runs, and confirming `--force` cleanly restores
 the pristine file.
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -44,6 +44,15 @@ eval against the course's own exercises/solutions is now piloted for 2 exercises
 entry below and `docs/eval/README.md` — with several mapped exercises still deferred to a
 follow-up. Phase 4 is done for what's in-scope for this repo — see the entry below.
 
+**CI workflow hardening (2026-09-04, issue #49)**: addressed five CI hardening and test quality issues in
+`.github/workflows/ci.yml`: (1) pinned third-party `DavidAnson/markdownlint-cli2-action` to full 40-character
+commit SHA `21c1be1b93ad9ed58fa840aacc3f279cde2a72ff` (`v24`); (2) declared top-level `permissions: contents: read`
+to enforce the principle of least privilege; (3) configured explicit `timeout-minutes` on all 6 jobs (5m for lints/checks,
+10m for smoke test) to avoid hung runners; (4) added a top-level `concurrency` group with `cancel-in-progress: true`
+to cancel superseded runs on rapid pushes; (5) hardened the `install-smoke-test` "no overwrite" verification by appending
+a canary modification, asserting SHA256 checksum identity across skipped re-runs, and confirming `--force` cleanly restores
+the pristine file.
+
 **Upstream drift check robustness hardening (2026-09-04, issue #48)**: addressed four robustness issues in
 `scripts/check-upstream-drift.sh`: (1) separated `gh api` stdout and stderr via a temporary error file, preventing
 CLI warnings on stderr from corrupting metadata header parsing; (2) added explicit validation of GitHub compare's


### PR DESCRIPTION
## Summary
Fixes #49.

Addressed five CI hardening and test quality issues in `.github/workflows/ci.yml`:
1. Pinned third-party `DavidAnson/markdownlint-cli2-action` to full 40-character commit SHA `21c1be1b93ad9ed58fa840aacc3f279cde2a72ff` (`v24`).
2. Declared top-level `permissions: contents: read` to enforce the principle of least privilege.
3. Configured explicit `timeout-minutes` on all 6 jobs (5m for lints/checks, 10m for smoke test) to avoid hung runners.
4. Added a top-level `concurrency` group with `cancel-in-progress: true` to cancel superseded runs on rapid pushes.
5. Hardened the `install-smoke-test` "no overwrite" verification by appending a canary modification, asserting SHA256 checksum identity across skipped re-runs, and confirming `--force` cleanly restores the pristine file.

## Verification
- Planning review conducted via read-only subagent (§2.1).
- YAML syntax validated with Python `yaml.safe_load`.
- Local smoke test verification: confirmed canary modification survives skipped re-run with matching checksum, and is cleanly overwritten by `--force` with exact file identity.
- Quality gate checks run: `shellcheck`, `check-skill-frontmatter.sh`, `check-install-list-sync.sh`, `check-links.sh`, `markdownlint-cli2`.