### PR TITLE
fix: claude-code workflow error handling, dynamic ids, pagination, and timeout (#50)

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -30,27 +30,20 @@ on:
   issues:
     types: [labeled]
 
-# IDs below are specific to https://github.com/users/takurot/projects/1
-# (owner: takurot). Re-fetch and update these if the project is recreated
-# or its Status field/options are edited:
-#   gh api graphql -f query='
-#     query($login: String!, $number: Int!) {
-#       user(login: $login) { projectV2(number: $number) { id
-#         field(name: "Status") { ... on ProjectV2SingleSelectField {
-#           id options { id name } } } } } }' -f login=takurot -F number=1
+# The PROJECT_ID below is specific to https://github.com/users/takurot/projects/1
+# (owner: takurot). The "Status" field ID and "In Progress" option ID are dynamically
+# resolved from this PROJECT_ID at runtime, avoiding stale hardcoded field/option IDs.
 env:
   PROJECT_ID: PVT_kwHOAmN8-84Bh1Sx
-  STATUS_FIELD_ID: PVTSSF_lAHOAmN8-84Bh1Sxzhgvjx4
-  IN_PROGRESS_OPTION_ID: 47fc9ee4
 
 jobs:
   mark-in-progress:
     if: github.event.label.name == 'claude-code'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions: {}
     steps:
       - name: Move project item to In Progress
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
           PROJECTS_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
@@ -62,18 +55,40 @@ jobs:
             exit 0
           fi
 
+          # Dynamically resolve Status field and "In Progress" option from PROJECT_ID
+          status_fields="$(gh api graphql -f query='
+            query($projectId: ID!) {
+              node(id: $projectId) {
+                ... on ProjectV2 {
+                  field(name: "Status") {
+                    ... on ProjectV2SingleSelectField {
+                      id
+                      options { id name }
+                    }
+                  }
+                }
+              }
+            }' -f projectId="$PROJECT_ID" \
+            --jq '[.data.node.field.id // empty, ([.data.node.field.options[]? | select(.name == "In Progress") | .id][0] // empty)] | @tsv')"
+
+          read -r field_id option_id <<< "$status_fields"
+
+          if [[ -z "${field_id:-}" || -z "${option_id:-}" ]]; then
+            echo "Error: could not resolve 'Status' field or 'In Progress' option in Project $PROJECT_ID" >&2
+            exit 1
+          fi
+
           item_id="$(gh api graphql -f query='
             query($issueId: ID!) {
               node(id: $issueId) {
                 ... on Issue {
-                  projectItems(first: 20) {
+                  projectItems(first: 100) {
                     nodes { id project { id } }
                   }
                 }
               }
             }' -f issueId="$ISSUE_NODE_ID" \
-            --jq ".data.node.projectItems.nodes[] | select(.project.id == \"$PROJECT_ID\") | .id" \
-            | head -1)"
+            --jq "[.data.node.projectItems.nodes[]? | select(.project.id == \"$PROJECT_ID\") | .id][0] // empty")"
 
           if [[ -z "$item_id" ]]; then
             echo "Issue is not (yet) an item in $PROJECT_ID — skipping Status update." >&2
@@ -93,5 +108,5 @@ jobs:
             }' \
             -f projectId="$PROJECT_ID" \
             -f itemId="$item_id" \
-            -f fieldId="$STATUS_FIELD_ID" \
-            -f optionId="$IN_PROGRESS_OPTION_ID"
+            -f fieldId="$field_id" \
+            -f optionId="$option_id"

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -44,6 +44,14 @@ eval against the course's own exercises/solutions is now piloted for 2 exercises
 entry below and `docs/eval/README.md` — with several mapped exercises still deferred to a
 follow-up. Phase 4 is done for what's in-scope for this repo — see the entry below.
 
+**Project automation workflow hardening (2026-09-04, issue #50)**: addressed four reliability and robustness
+issues in `.github/workflows/claude-code.yml`: (1) removed `continue-on-error: true` so genuine API failures
+(expired tokens, mutation errors, network issues) trigger alerts instead of being silently swallowed;
+(2) replaced brittle hardcoded `STATUS_FIELD_ID` and `IN_PROGRESS_OPTION_ID` with dynamic runtime resolution from
+`PROJECT_ID` via GraphQL; (3) expanded `projectItems(first: 20)` to `first: 100` and replaced `head -1` pipe with
+`--jq` array indexing `[...][0] // empty`, eliminating broken pipe SIGPIPE (exit 141) risks under `set -eo pipefail`;
+(4) added `timeout-minutes: 5` to the `mark-in-progress` job.
+
 **CI workflow hardening (2026-09-04, issue #49)**: addressed five CI hardening and test quality issues in
 `.github/workflows/ci.yml`: (1) pinned third-party `DavidAnson/markdownlint-cli2-action` to full 40-character
 commit SHA `21c1be1b93ad9ed58fa840aacc3f279cde2a72ff` (`v24`); (2) declared top-level `permissions: contents: read`


### PR DESCRIPTION
## Summary
Fixes #50.

Addressed four reliability and robustness issues in `.github/workflows/claude-code.yml`:
1. Removed `continue-on-error: true` so genuine API failures (expired tokens, mutation errors, network issues) trigger alerts instead of being silently swallowed.
2. Replaced brittle hardcoded `STATUS_FIELD_ID` and `IN_PROGRESS_OPTION_ID` with dynamic runtime resolution from `PROJECT_ID` via GraphQL.
3. Expanded `projectItems(first: 20)` to `first: 100` and replaced `head -1` pipe with `--jq` array indexing `[...][0] // empty`, eliminating broken pipe SIGPIPE (exit 141) risks under `set -eo pipefail`.
4. Added `timeout-minutes: 5` to the `mark-in-progress` job.

## Verification
- Planning review conducted via read-only subagent (§2.1).
- YAML syntax validated with Python `yaml.safe_load`.
- Live GraphQL test: confirmed dynamic runtime resolution of Status field ID (`PVTSSF_lAHOAmN8-84Bh1Sxzhgvjx4`) and "In Progress" option ID (`47fc9ee4`) against project `PVT_kwHOAmN8-84Bh1Sx`.
- Live GraphQL test: confirmed issue project item resolution with `first: 100` and `[0] // empty` without SIGPIPE risk.
- Quality gate checks run: `shellcheck`, `check-skill-frontmatter.sh`, `check-install-list-sync.sh`, `check-links.sh`, `markdownlint-cli2`.